### PR TITLE
Willem/committee add constituents

### DIFF
--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -403,9 +403,9 @@ pub mod pallet {
     /// The existing council can then vote to add them as concil members
     impl<T: Config> ChangeMembers<AccountIdFor<T>> for Pallet<T> {
         fn change_members_sorted(
-            _incoming: &[AccountIdFor<T>],
+            incoming: &[AccountIdFor<T>],
             outgoing: &[AccountIdFor<T>],
-            new: &[AccountIdFor<T>],
+            _sorted_new: &[AccountIdFor<T>],
         ) {
             // Remove outgoing members from any currently active votes
             for proposal_hash in ActiveProposals::<T>::get() {
@@ -415,8 +415,10 @@ pub mod pallet {
                     }
                 });
             }
-            Members::<T>::drain().for_each(drop); // remove all the members from the map
-            for member in new {
+            for leaving_member in outgoing {
+                Members::<T>::remove(leaving_member)
+            }
+            for member in incoming {
                 Members::<T>::insert(member, MemberType::Constituent);
             }
         }

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -387,8 +387,9 @@ pub mod pallet {
     impl<T: Config> InitializeMembers<AccountIdFor<T>> for Pallet<T> {
         fn initialize_members(members: &[AccountIdFor<T>]) {
             if !members.is_empty() {
-                assert!(
-                    Members::<T>::iter().count() == 0,
+                assert_eq!(
+                    Members::<T>::iter().count(),
+                    0,
                     "Members are already initialized!"
                 );
                 for member in members {

--- a/pallets/committee/src/mock.rs
+++ b/pallets/committee/src/mock.rs
@@ -77,12 +77,14 @@ pub(crate) const EXECUTER_ACCOUNT_ID: AccountId = 88;
 ord_parameter_types! {
     pub const AdminAccountId: AccountId = PROPOSER_ACCOUNT_ID;
     pub const ExecuterAccountId: AccountId = EXECUTER_ACCOUNT_ID;
+    pub const MinCouncilVotes: usize = 4;
 
 }
 
 impl pallet_committee::Config for Test {
     type ProposalSubmissionPeriod = ProposalSubmissionPeriod;
     type VotingPeriod = VotingPeriod;
+    type MinCouncilVotes = MinCouncilVotes;
     type ProposalSubmissionOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
     type ProposalExecutionOrigin = frame_system::EnsureSignedBy<ExecuterAccountId, AccountId>;
     type ProposalNonce = u32;

--- a/pallets/committee/src/mock.rs
+++ b/pallets/committee/src/mock.rs
@@ -73,11 +73,12 @@ parameter_types! {
 }
 pub(crate) const PROPOSER_ACCOUNT_ID: AccountId = 88;
 pub(crate) const EXECUTER_ACCOUNT_ID: AccountId = 88;
+pub(crate) const MIN_COUNCIL_VOTES: usize = 4;
 
 ord_parameter_types! {
     pub const AdminAccountId: AccountId = PROPOSER_ACCOUNT_ID;
     pub const ExecuterAccountId: AccountId = EXECUTER_ACCOUNT_ID;
-    pub const MinCouncilVotes: usize = 4;
+    pub const MinCouncilVotes: usize = MIN_COUNCIL_VOTES;
 
 }
 

--- a/pallets/committee/src/tests.rs
+++ b/pallets/committee/src/tests.rs
@@ -3,13 +3,18 @@
 
 use crate as pallet;
 use crate::mock::*;
-use crate::{Vote, VoteAggregate};
+use crate::{CommitteeMember, MemberType, Vote, VoteAggregate};
 use frame_support::{assert_noop, assert_ok, codec::Encode, traits::InitializeMembers};
 use frame_system as system;
 use sp_runtime::traits::BadOrigin;
 use std::convert::TryFrom;
 
 const ASHLEY: AccountId = 0;
+
+const ASHLEY_COUNCIL: CommitteeMember<AccountId> = CommitteeMember {
+    account_id: ASHLEY,
+    member_type: MemberType::Council,
+};
 
 // Start of the first submission period
 const START_OF_S1: <Test as system::Config>::BlockNumber =
@@ -160,7 +165,7 @@ fn member_can_vote_in_voting_period() {
     new_test_ext().execute_with(|| {
         Committee::initialize_members(&[ASHLEY]);
         let expected_votes =
-            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY], vec![], vec![], START_OF_V1);
+            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY_COUNCIL], vec![], vec![], START_OF_V1);
         let proposal = submit_proposal(123);
 
         run_to_block(START_OF_S1 - 1);
@@ -189,7 +194,7 @@ fn member_can_vote_aye() {
     new_test_ext().execute_with(|| {
         Committee::initialize_members(&[ASHLEY]);
         let expected_votes =
-            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY], vec![], vec![], START_OF_V1);
+            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY_COUNCIL], vec![], vec![], START_OF_V1);
         let proposal = submit_proposal(123);
         run_to_block(START_OF_S1);
         // first block in voting period
@@ -210,7 +215,7 @@ fn member_can_vote_nay() {
     new_test_ext().execute_with(|| {
         Committee::initialize_members(&[ASHLEY]);
         let expected_votes =
-            VoteAggregate::<AccountId, u64>::new(vec![], vec![ASHLEY], vec![], START_OF_V1);
+            VoteAggregate::<AccountId, u64>::new(vec![], vec![ASHLEY_COUNCIL], vec![], START_OF_V1);
         let proposal = submit_proposal(123);
         run_to_block(START_OF_S1);
         assert_ok!(Committee::vote(
@@ -230,7 +235,7 @@ fn member_can_vote_abstain() {
     new_test_ext().execute_with(|| {
         Committee::initialize_members(&[ASHLEY]);
         let expected_votes =
-            VoteAggregate::<AccountId, u64>::new(vec![], vec![], vec![ASHLEY], START_OF_V1);
+            VoteAggregate::<AccountId, u64>::new(vec![], vec![], vec![ASHLEY_COUNCIL], START_OF_V1);
         let proposal = submit_proposal(123);
         run_to_block(START_OF_S1);
         assert_ok!(Committee::vote(
@@ -274,7 +279,7 @@ fn member_cannot_vote_multiple_times() {
         Committee::initialize_members(&[ASHLEY]);
         let proposal = submit_proposal(123);
         let expected_votes =
-            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY], vec![], vec![], START_OF_V1);
+            VoteAggregate::<AccountId, u64>::new(vec![ASHLEY_COUNCIL], vec![], vec![], START_OF_V1);
 
         run_to_block(START_OF_S1);
         assert_ok!(Committee::vote(

--- a/pallets/committee/src/tests.rs
+++ b/pallets/committee/src/tests.rs
@@ -4,7 +4,11 @@
 use crate as pallet;
 use crate::mock::*;
 use crate::{CommitteeMember, MemberType, Vote, VoteAggregate};
-use frame_support::{assert_noop, assert_ok, codec::Encode, traits::{InitializeMembers, ChangeMembers}};
+use frame_support::{
+    assert_noop, assert_ok,
+    codec::Encode,
+    traits::{ChangeMembers, InitializeMembers},
+};
 use frame_system as system;
 use sp_runtime::traits::BadOrigin;
 use std::convert::{TryFrom, TryInto};
@@ -302,7 +306,6 @@ fn member_cannot_vote_multiple_times() {
 // Closing/executing a proposal
 //
 
-
 // iterates through accounts and vote a particular way on a proposal
 fn vote_with_each<I>(accounts: I, proposal_hash: <Test as system::Config>::Hash, vote: Vote)
 where
@@ -332,7 +335,7 @@ where
     I: IntoIterator<Item = AccountId>,
 {
     let members: Vec<u64> = accounts.into_iter().collect();
-    Committee::change_members(&members, &[], Vec::new());   
+    Committee::change_members(&members, &[], Vec::new());
 }
 
 #[test]
@@ -373,7 +376,11 @@ fn cannot_close_if_insufficent_council_votes() {
         let proposal = submit_proposal(123);
 
         run_to_block(START_OF_S1);
-        vote_with_each(0..(MIN_COUNCIL_VOTES - 1).try_into().unwrap(), proposal.hash(), Vote::Aye);
+        vote_with_each(
+            0..(MIN_COUNCIL_VOTES - 1).try_into().unwrap(),
+            proposal.hash(),
+            Vote::Aye,
+        );
 
         run_to_block(START_OF_V1 + 1);
         assert_noop!(
@@ -390,7 +397,11 @@ fn cannot_close_if_council_rejects() {
         let proposal = submit_proposal(123);
 
         run_to_block(START_OF_S1);
-        vote_with_each(0..(MIN_COUNCIL_VOTES).try_into().unwrap(), proposal.hash(), Vote::Nay);
+        vote_with_each(
+            0..(MIN_COUNCIL_VOTES).try_into().unwrap(),
+            proposal.hash(),
+            Vote::Nay,
+        );
 
         run_to_block(START_OF_V1 + 1);
         assert_noop!(

--- a/pallets/committee/src/types.rs
+++ b/pallets/committee/src/types.rs
@@ -162,7 +162,7 @@ impl<AccountId: Default + PartialEq, BlockNumber: Default> VoteAggregate<Account
         );
         ensure!(ayes > nays, VoteRejectionReason::CouncilDeny);
         ensure!(cons_nays <= cons_ayes, VoteRejectionReason::ConstituentVeto);
-        
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Changes

Adds the two-layer governance (council and constituents) to the committee pallet.

- Members now have an associated membership type and are stored in a StorageMap
- initialize_members adds initial members as council
- change_members allows for adding constituent members only
- Refactor of VotesAggregate to store a single vec of votes rather than three for ayes, nays and abstains
- Change vote acceptance criteria to allow the constituent members to veto
- Adds type parameter for MinCouncilVotes required to pass an action
- Adds additonal error types for the different reasons a proposal can be rejected
- Refactor tests

## Tests

```
cargo test
```

New tests added for constituent veto logic

## Issues
- Closes #36 