### PR TITLE
feat: add asset depository pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-depository"
+version = "0.0.1"
+dependencies = [
+ "frame-support 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
+ "frame-system 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
+ "pallet-balances",
+ "parity-scale-codec",
+ "serde",
+ "sp-core 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
+ "sp-io 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
+ "sp-runtime 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
+]
+
+[[package]]
 name = "pallet-asset-index"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,7 +4592,6 @@ version = "0.0.1"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
  "frame-system 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",
- "pallet-balances",
  "parity-scale-codec",
  "serde",
  "sp-core 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=rococo-v1)",

--- a/pallets/asset-depository/Cargo.toml
+++ b/pallets/asset-depository/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+authors = ['ChainSafe Systems']
+description = 'FRAME pallet to treat multiple deposited assets as currencies.'
+edition = '2018'
+license = 'LGPL-3.0-only'
+name = 'pallet-asset-depository'
+readme = 'README.md'
+repository = 'https://github.com/ChainSafe/PINT/'
+version = '0.0.1'
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+]
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '2.0.0'
+
+[dependencies.frame-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[dependencies.frame-system]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[dev-dependencies]
+serde = { version = "1.0.101" }
+
+[dev-dependencies.pallet-balances]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[dev-dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[dev-dependencies.sp-io]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[dev-dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = 'rococo-v1'
+version = '3.0.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/asset-depository/Cargo.toml
+++ b/pallets/asset-depository/Cargo.toml
@@ -36,12 +36,6 @@ version = '3.0.0'
 [dev-dependencies]
 serde = { version = "1.0.101" }
 
-[dev-dependencies.pallet-balances]
-default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-branch = 'rococo-v1'
-version = '3.0.0'
-
 [dev-dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'

--- a/pallets/asset-depository/README.md
+++ b/pallets/asset-depository/README.md
@@ -1,0 +1,1 @@
+License: LGPL-3.0-only

--- a/pallets/asset-depository/src/lib.rs
+++ b/pallets/asset-depository/src/lib.rs
@@ -16,7 +16,7 @@ mod types;
 // this is requires as the #[pallet::event] proc macro generates code that violates this lint
 #[allow(clippy::unused_unit)]
 pub mod pallet {
-    use crate::traits::MultiAssetDepository;
+    pub use crate::traits::MultiAssetDepository;
     use crate::types::AccountBalance;
     use frame_support::sp_runtime::traits::{CheckedAdd, CheckedSub};
     use frame_support::{

--- a/pallets/asset-depository/src/lib.rs
+++ b/pallets/asset-depository/src/lib.rs
@@ -105,7 +105,6 @@ pub mod pallet {
     }
 
     impl<T: Config> MultiAssetDepository<T::AssetId, AccountIdFor<T>, T::Balance> for Pallet<T> {
-
         /// The total amount of the given asset currently held
         fn aggregated_balance(asset_id: &T::AssetId) -> T::Balance {
             TotalBalance::<T>::get(asset_id)

--- a/pallets/asset-depository/src/lib.rs
+++ b/pallets/asset-depository/src/lib.rs
@@ -1,0 +1,151 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+//! # Asset Depository Pallet
+//!
+//! Provides support for storing the balances of multiple assets
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+mod traits;
+mod types;
+
+#[frame_support::pallet]
+// this is requires as the #[pallet::event] proc macro generates code that violates this lint
+#[allow(clippy::unused_unit)]
+pub mod pallet {
+    use crate::types::AccountBalance;
+    use frame_support::{
+        pallet_prelude::*,
+        sp_runtime::{
+            traits::{AtLeast32BitUnsigned, Zero},
+        }
+    };
+    use frame_system::pallet_prelude::*;
+    use frame_support::sp_runtime::traits::{CheckedAdd, CheckedSub};
+    use crate::traits::MultiAssetDepository;
+
+    type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The balance type for cross chain transfers
+        type Balance: Parameter + Member + AtLeast32BitUnsigned + Default + Copy + MaybeSerializeDeserialize;
+
+        /// Asset Id that is used to identify different kinds of assets.
+        type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + Ord;
+
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub (super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    /// The balances the assets stored for an account.
+	///
+	/// This is used to temporarily store balances for assets.
+    #[pallet::storage]
+    pub type Accounts<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        AccountIdFor<T>,
+        Twox64Concat,
+        T::AssetId,
+        AccountBalance<T::Balance>,
+        ValueQuery,
+    >;
+
+    /// The aggregated balance of an asset.
+    #[pallet::storage]
+    pub type TotalBalance<T: Config> = StorageMap<_, Twox64Concat, T::AssetId, T::Balance, ValueQuery>;
+
+    #[pallet::event]
+    pub enum Event<T: Config> {}
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Thrown when depositing an amount of an asset has caused an overflow of the aggregated balance.
+        TotalBalanceOverflow,
+        /// Thrown when depositing amount into an user account caused an overflow.
+        BalanceOverflow,
+        /// Thrown when withdrawing would cause an underflow
+        NotEnoughBalance
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {}
+
+    impl<T: Config> Pallet<T> {
+
+        /// The total amount of the given asset currently held
+       pub fn aggregated_balance(asset_id: &T::AssetId) -> T::Balance {
+            TotalBalance::<T>::get(asset_id)
+        }
+
+        /// The total balance of an asset of a user
+       pub fn total_balance(asset_id: &T::AssetId, who: & AccountIdFor<T>,) -> T::Balance {
+            Accounts::<T>::get(who, asset_id).total_balance()
+        }
+
+        /// The current available balance of an asset of a user
+        pub fn available_balance(asset_id: &T::AssetId, who: & AccountIdFor<T>) -> T::Balance {
+            Accounts::<T>::get(who, asset_id).available
+        }
+
+        /// Set the available balance of the given account the given value.
+        pub(crate) fn set_available_balance(asset_id: &T::AssetId, who: & AccountIdFor<T>, amount: T::Balance) {
+            Accounts::<T>::mutate(who, asset_id, |account| {
+                account.available = amount;
+            });
+        }
+    }
+
+    impl<T: Config> MultiAssetDepository<T::AssetId, AccountIdFor<T>, T::Balance> for Pallet<T> {
+        /// Deposit the `amount` of the given asset into the available balance of the given account `who`.
+        fn deposit(asset_id: &T::AssetId, who: & AccountIdFor<T>, amount: T::Balance) -> DispatchResult {
+            if amount.is_zero() {
+                return Ok(());
+            }
+
+            TotalBalance::<T>::try_mutate(asset_id, |total| -> DispatchResult {
+                *total = total
+                    .checked_add(&amount)
+                    .ok_or(Error::<T>::TotalBalanceOverflow)?;
+
+                // SAFETY: this can't overflow because the balance for an account is
+                //  at most equal to the total balance and adding to it already succeeded
+                Self::set_available_balance(&asset_id, who, Self::available_balance(&asset_id, who) + amount);
+
+                Ok(())
+            })
+        }
+
+        /// Withdraw the `amount` of the given asset from the available balance of the given account `who`.
+        fn withdraw(asset_id: &T::AssetId, who: & AccountIdFor<T>, amount: T::Balance) -> DispatchResult {
+            if amount.is_zero() {
+                return Ok(());
+            }
+
+            Accounts::<T>::try_mutate(who, &asset_id, |balance| -> DispatchResult {
+                balance.available = balance.available
+                    .checked_sub(&amount)
+                    .ok_or(Error::<T>::NotEnoughBalance)?;
+                Ok(())
+            })?;
+
+            // SAFETY: this can't underflow because the total balance for an asset is at least
+            //  equal to the total balance in the given account and subtracting already succeeded
+            TotalBalance::<T>::mutate(asset_id, |total| {
+                *total -= amount
+            });
+
+            Ok(())
+        }
+    }
+}

--- a/pallets/asset-depository/src/lib.rs
+++ b/pallets/asset-depository/src/lib.rs
@@ -9,6 +9,12 @@
 
 pub use pallet::*;
 
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
 mod traits;
 mod types;
 
@@ -86,21 +92,6 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {}
 
     impl<T: Config> Pallet<T> {
-        /// The total amount of the given asset currently held
-        pub fn aggregated_balance(asset_id: &T::AssetId) -> T::Balance {
-            TotalBalance::<T>::get(asset_id)
-        }
-
-        /// The total balance of an asset of a user
-        pub fn total_balance(asset_id: &T::AssetId, who: &AccountIdFor<T>) -> T::Balance {
-            Accounts::<T>::get(who, asset_id).total_balance()
-        }
-
-        /// The current available balance of an asset of a user
-        pub fn available_balance(asset_id: &T::AssetId, who: &AccountIdFor<T>) -> T::Balance {
-            Accounts::<T>::get(who, asset_id).available
-        }
-
         /// Set the available balance of the given account the given value.
         pub(crate) fn set_available_balance(
             asset_id: &T::AssetId,
@@ -114,6 +105,22 @@ pub mod pallet {
     }
 
     impl<T: Config> MultiAssetDepository<T::AssetId, AccountIdFor<T>, T::Balance> for Pallet<T> {
+
+        /// The total amount of the given asset currently held
+        fn aggregated_balance(asset_id: &T::AssetId) -> T::Balance {
+            TotalBalance::<T>::get(asset_id)
+        }
+
+        /// The total balance of an asset of a user
+        fn total_balance(asset_id: &T::AssetId, who: &AccountIdFor<T>) -> T::Balance {
+            Accounts::<T>::get(who, asset_id).total_balance()
+        }
+
+        /// The current available balance of an asset of a user
+        fn available_balance(asset_id: &T::AssetId, who: &AccountIdFor<T>) -> T::Balance {
+            Accounts::<T>::get(who, asset_id).available
+        }
+
         /// Deposit the `amount` of the given asset into the available balance of the given account `who`.
         fn deposit(
             asset_id: &T::AssetId,

--- a/pallets/asset-depository/src/mock.rs
+++ b/pallets/asset-depository/src/mock.rs
@@ -1,0 +1,82 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Required as construct_runtime! produces code that violates this lint
+#![allow(clippy::from_over_into)]
+
+use crate as pallet_asset_depository;
+use frame_support::traits::StorageMapShim;
+use frame_support::{ord_parameter_types, parameter_types, Parameter};
+use frame_system as system;
+
+use frame_support::pallet_prelude::{MaybeSerializeDeserialize, Member};
+use frame_support::sp_runtime::traits::AtLeast32BitUnsigned;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    DispatchError,
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        AssetDepository: pallet_asset_depository::{Pallet, Call, Storage, Event<T>},
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+}
+
+pub(crate) type Balance = u64;
+pub(crate) type AccountId = u64;
+
+impl system::Config for Test {
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+}
+
+impl pallet_asset_depository::Config for Test {
+    type Event = Event;
+    type AssetId = u32;
+    type Balance = u128;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
+}

--- a/pallets/asset-depository/src/mock.rs
+++ b/pallets/asset-depository/src/mock.rs
@@ -5,17 +5,13 @@
 #![allow(clippy::from_over_into)]
 
 use crate as pallet_asset_depository;
-use frame_support::traits::StorageMapShim;
-use frame_support::{ord_parameter_types, parameter_types, Parameter};
+use frame_support::parameter_types;
 use frame_system as system;
 
-use frame_support::pallet_prelude::{MaybeSerializeDeserialize, Member};
-use frame_support::sp_runtime::traits::AtLeast32BitUnsigned;
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    DispatchError,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -38,7 +34,6 @@ parameter_types! {
     pub const SS58Prefix: u8 = 42;
 }
 
-pub(crate) type Balance = u64;
 pub(crate) type AccountId = u64;
 
 impl system::Config for Test {

--- a/pallets/asset-depository/src/tests.rs
+++ b/pallets/asset-depository/src/tests.rs
@@ -1,0 +1,42 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+use crate as pallet;
+use crate::mock::*;
+use frame_support::{assert_noop, assert_ok};
+use pallet::MultiAssetDepository;
+
+const ASHLEY: AccountId = 0;
+const BOB: AccountId = 1;
+const ASSET_A: u32 = 0;
+
+#[test]
+fn depositing_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AssetDepository::deposit(&ASSET_A, &ASHLEY, 100));
+        assert_noop!(
+            AssetDepository::deposit(&ASSET_A, &BOB, u128::MAX),
+            pallet::Error::<Test>::TotalBalanceOverflow
+        );
+        assert_ok!(AssetDepository::deposit(&ASSET_A, &BOB, 2_000));
+
+        assert_eq!(AssetDepository::total_balance(&ASSET_A, &ASHLEY), 100);
+        assert_eq!(AssetDepository::aggregated_balance(&ASSET_A), 2_100);
+    });
+}
+
+#[test]
+fn withdrawing_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AssetDepository::deposit(&ASSET_A, &ASHLEY, 100));
+        assert_ok!(AssetDepository::deposit(&ASSET_A, &BOB, 2_000));
+
+        assert_ok!(AssetDepository::withdraw(&ASSET_A, &BOB, 2_000));
+        assert_eq!(AssetDepository::aggregated_balance(&ASSET_A), 100);
+
+        assert_noop!(
+            AssetDepository::withdraw(&ASSET_A, &BOB, 1),
+            pallet::Error::<Test>::NotEnoughBalance
+        );
+    });
+}

--- a/pallets/asset-depository/src/traits.rs
+++ b/pallets/asset-depository/src/traits.rs
@@ -5,7 +5,6 @@ use frame_support::sp_runtime::DispatchResult;
 
 /// An abstraction over the multiple balances for different assets
 pub trait MultiAssetDepository<AssetId, AccountId, Balance> {
-
     /// Add `amount` to the balance of `who` under `asset_id`.
     fn deposit(asset_id: &AssetId, who: &AccountId, amount: Balance) -> DispatchResult;
 

--- a/pallets/asset-depository/src/traits.rs
+++ b/pallets/asset-depository/src/traits.rs
@@ -5,6 +5,15 @@ use frame_support::sp_runtime::DispatchResult;
 
 /// An abstraction over the multiple balances for different assets
 pub trait MultiAssetDepository<AssetId, AccountId, Balance> {
+    /// The total amount of the given asset currently held
+    fn aggregated_balance(asset_id: &AssetId) -> Balance;
+
+    /// The total balance of an asset of a user
+    fn total_balance(asset_id: &AssetId, who: &AccountId) -> Balance;
+
+    /// The current available balance of an asset of a user
+    fn available_balance(asset_id: &AssetId, who: &AccountId) -> Balance;
+    
     /// Add `amount` to the balance of `who` under `asset_id`.
     fn deposit(asset_id: &AssetId, who: &AccountId, amount: Balance) -> DispatchResult;
 

--- a/pallets/asset-depository/src/traits.rs
+++ b/pallets/asset-depository/src/traits.rs
@@ -13,7 +13,7 @@ pub trait MultiAssetDepository<AssetId, AccountId, Balance> {
 
     /// The current available balance of an asset of a user
     fn available_balance(asset_id: &AssetId, who: &AccountId) -> Balance;
-    
+
     /// Add `amount` to the balance of `who` under `asset_id`.
     fn deposit(asset_id: &AssetId, who: &AccountId, amount: Balance) -> DispatchResult;
 

--- a/pallets/asset-depository/src/traits.rs
+++ b/pallets/asset-depository/src/traits.rs
@@ -1,0 +1,14 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+use frame_support::sp_runtime::DispatchResult;
+
+/// An abstraction over the multiple balances for different assets
+pub trait MultiAssetDepository<AssetId, AccountId, Balance> {
+
+    /// Add `amount` to the balance of `who` under `asset_id`.
+    fn deposit(asset_id: &AssetId, who: &AccountId, amount: Balance) -> DispatchResult;
+
+    /// Remove `amount` from the balance of `who` under `asset_id`.
+    fn withdraw(asset_id: &AssetId, who: &AccountId, amount: Balance) -> DispatchResult;
+}

--- a/pallets/asset-depository/src/types.rs
+++ b/pallets/asset-depository/src/types.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+use frame_support::sp_runtime::{traits::Saturating, RuntimeDebug};
+use codec::{Encode, Decode};
+
+/// Represents the balance of a single asset.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct AccountBalance<Balance> {
+    /// Non-reserved part of the balance. There may still be restrictions on
+    /// this, but it is the total pool what may in principle be transferred,
+    /// reserved.
+    ///
+    /// This is the only balance that matters in terms of most operations on
+    /// tokens.
+    pub available: Balance,
+    /// Balance which is currently locked and can't be accessed by the user.
+    ///
+    /// This is intended to reserve an amount of this asset for PINT related operations, so that it can be spend.
+    pub reserved: Balance,
+}
+
+
+impl<Balance: Saturating + Copy + Ord> AccountBalance<Balance> {
+    /// The total balance that is currently reserved and available
+    pub fn total_balance(&self) -> Balance {
+        self.available.saturating_add(self.reserved)
+    }
+}

--- a/pallets/asset-depository/src/types.rs
+++ b/pallets/asset-depository/src/types.rs
@@ -1,8 +1,8 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
+use codec::{Decode, Encode};
 use frame_support::sp_runtime::{traits::Saturating, RuntimeDebug};
-use codec::{Encode, Decode};
 
 /// Represents the balance of a single asset.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
@@ -19,7 +19,6 @@ pub struct AccountBalance<Balance> {
     /// This is intended to reserve an amount of this asset for PINT related operations, so that it can be spend.
     pub reserved: Balance,
 }
-
 
 impl<Balance: Saturating + Copy + Ord> AccountBalance<Balance> {
     /// The total balance that is currently reserved and available


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Adds an additional palette which sole purpose is to track asset balances for a user
- It's abstracted via the `MultiAssetDepository` trait, which is intended to be included in the asset transaction routine for depositing and withdrawing funds on a cross-chain message issued by a user

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Adds the necessary depository functionality for #25 in order to deposit cross chain assets https://github.com/ChainSafe/PINT/issues/25#issuecomment-824926629 to temporarily store them before converting them to PINT or withdrawing them via XCM upon a user request 