### PR TITLE
ci(docker): hotfix the trigger of publishing docker images by tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,4 +197,4 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: main
+              ignore: /.*/


### PR DESCRIPTION
This is really a small fix, I can embed this into my next PR or @mattsse doesn't mind adding this fix to your pending PRs?

## Changes

Forgot to ignore all branches in my last PR #49, and here is the doc of CircieCI tag trigger, [Executing workflows for a git tag](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag)

## Tests

* [clearloop/PINT](https://github.com/clearloop/pint) ( still building now )

Tested on my private repo, [echo-when-tag](https://app.circleci.com/pipelines/github/clearloop/cydonia/7/workflows/874a3444-dfc7-4c7e-ab1b-efe0c0cdf2fd/jobs/8), it would be nice downloading the testing  [config.yml](https://github.com/clearloop/cydonia/blob/master/.circleci/config.yml) or merge this branch into a personal fork of PINT to test this instruction

---

BTW, can anybody delete [this test release](https://github.com/ChainSafe/PINT/releases/tag/v0.0.1-test)?