### PR TITLE
feat(config): use statemint as parachain

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,25 +22,27 @@
   },
   "parachains": [
     {
-      "bin": "./target/release/pint",
+      "bin": "./target/target/pint",
       "chain": "pint-dev",
       "id": "1",
       "wsPort": 9988,
       "port": 31200,
       "balance": "1000000000000000000000",
       "flags": [
+        "-lruntime=debug",
         "--",
         "--execution=wasm"
       ]
     },
     {
-      "bin": "./target/release/pint",
-      "chain": "pint-dev",
+      "bin": "./bin/statemint",
+      "chain": "statemint-dev",
       "id": "300",
       "wsPort": 9999,
       "port": 31300,
       "balance": "1000000000000000000000",
       "flags": [
+        "-lruntime=debug",
         "--",
         "--execution=wasm"
       ]


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Add statemint to polkadot-launch config to launch statemint as a parachain and create channel from pint to statemint
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-