### PR TITLE
refactor: extract asset registry to new primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4805,6 +4805,7 @@ dependencies = [
  "pallet-price-feed",
  "pallet-remote-asset-manager",
  "parity-scale-codec",
+ "primitives",
  "serde",
  "sp-core",
  "sp-io",
@@ -5382,6 +5383,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
+ "primitives",
  "serde",
  "sp-core",
  "sp-io",
@@ -5738,6 +5740,7 @@ dependencies = [
  "parachain-info",
  "parity-scale-codec",
  "polkadot-parachain",
+ "primitives",
  "serde",
  "sp-api",
  "sp-block-builder",
@@ -7293,6 +7296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitives"
+version = "0.0.1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "xcm",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8416,10 +8430,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "sc-client-api",
- "sp-authorship 3.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4)",
+ "sp-authorship 3.0.0 (git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6)",
  "sp-runtime",
  "thiserror",
 ]
@@ -8427,10 +8441,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "sc-client-api",
- "sp-authorship 3.0.0 (git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6)",
+ "sp-authorship 3.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4)",
  "sp-runtime",
  "thiserror",
 ]
@@ -8640,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8659,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -9568,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9580,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9850,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9861,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=1d04678e20555e623c974ee1127bc8a45abcf3d6#1d04678e20555e623c974ee1127bc8a45abcf3d6"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
 dependencies = [
  "lazy_static",
  "sp-core",

--- a/pallets/asset-index/Cargo.toml
+++ b/pallets/asset-index/Cargo.toml
@@ -25,6 +25,7 @@ pallet-chainlink-feed = { git = "https://github.com/ChainSafe/chainlink-polkadot
 pallet-remote-asset-manager = { path = "../remote-asset-manager", default-features = false }
 pallet-asset-depository = { path = "../asset-depository", default-features = false }
 pallet-price-feed = { path = "../price-feed", default-features = false }
+primitives = { path = "../../primitives/primitives", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.101" }
@@ -44,6 +45,7 @@ std = [
     'pallet-remote-asset-manager/std',
     'pallet-asset-depository/std',
     'pallet-price-feed/std',
+    'primitives/std',
     'xcm/std',
     'xcm-executor/std',
 ]

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -45,13 +45,14 @@ pub mod pallet {
     use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
     use pallet_remote_asset_manager::RemoteAssetManager;
 
+    pub use crate::traits::AssetRecorder;
     use crate::traits::WithdrawalFee;
-    pub use crate::traits::{AssetRecorder, MultiAssetRegistry};
     pub use crate::types::MultiAssetAdapter;
     use crate::types::{
         AssetAvailability, AssetMetadata, AssetWithdrawal, IndexAssetData, PendingRedemption,
         RedemptionState,
     };
+    use primitives::traits::MultiAssetRegistry;
 
     type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 

--- a/pallets/asset-index/src/traits.rs
+++ b/pallets/asset-index/src/traits.rs
@@ -3,7 +3,6 @@
 
 pub use crate::types::{AssetAvailability, AssetMetadata};
 use frame_support::{dispatch::DispatchResult, sp_runtime::traits::AtLeast32BitUnsigned};
-use xcm::v0::MultiLocation;
 
 pub trait AssetRecorder<AssetId, Balance> {
     /// Add an asset to the recorder. If an asset with the given AssetId already exists
@@ -15,15 +14,6 @@ pub trait AssetRecorder<AssetId, Balance> {
         -> DispatchResult;
 
     fn remove_asset(id: &AssetId) -> DispatchResult;
-}
-
-/// Type that provides the mapping between `AssetId` and `MultiLocation`.
-pub trait MultiAssetRegistry<AssetId> {
-    /// Determines the relative location of the consensus system where the given asset is native from the point of view of the current system
-    fn native_asset_location(asset: &AssetId) -> Option<MultiLocation>;
-
-    /// Whether the given identifier is currently supported as a liquid asset
-    fn is_liquid_asset(asset: &AssetId) -> bool;
 }
 
 /// Type that calculations any fees to be deducted for every withdrawal.

--- a/pallets/asset-index/src/types.rs
+++ b/pallets/asset-index/src/types.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use crate::traits::MultiAssetRegistry;
 use codec::FullCodec;
 use frame_support::pallet_prelude::*;
 use frame_support::sp_runtime::traits::AtLeast32BitUnsigned;
@@ -15,6 +14,7 @@ use frame_support::sp_std::{
     result,
 };
 use pallet_asset_depository::MultiAssetDepository;
+use primitives::traits::MultiAssetRegistry;
 use xcm::v0::{Error as XcmError, MultiAsset, MultiLocation, Result};
 use xcm_executor::{
     traits::{Convert, MatchesFungible, TransactAsset},

--- a/pallets/remote-asset-manager/Cargo.toml
+++ b/pallets/remote-asset-manager/Cargo.toml
@@ -28,6 +28,7 @@ cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus', branc
 
 # PINT dependencies
 xcm-calls = {path = "../../primitives/xcm-calls", default-features = false }
+primitives = { path = "../../primitives/primitives", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.4', default-features = false }
@@ -49,6 +50,7 @@ std = [
     'xcm/std',
     'log/std',
     'xcm-calls/std',
+    'primitives/std',
     'xcm-executor/std',
     'cumulus-pallet-xcm/std',
     'cumulus-primitives-core/std',

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -16,23 +16,26 @@ mod traits;
 // this is requires as the #[pallet::event] proc macro generates code that violates this lint
 #[allow(clippy::unused_unit)]
 pub mod pallet {
+    pub use crate::traits::*;
     use cumulus_primitives_core::ParaId;
-    use frame_support::sp_runtime::traits::Zero;
     use frame_support::{
         dispatch::DispatchResultWithPostInfo,
         pallet_prelude::*,
-        sp_runtime::traits::{AtLeast32BitUnsigned, Convert, StaticLookup},
+        sp_runtime::{
+            traits::Zero,
+            traits::{AtLeast32BitUnsigned, Convert, StaticLookup},
+        },
         sp_std::prelude::*,
         traits::Get,
     };
     use frame_system::pallet_prelude::*;
+    use primitives::traits::MultiAssetRegistry;
     use xcm::{
         opaque::v0::SendXcm,
         v0::{ExecuteXcm, MultiLocation, OriginKind, Xcm},
     };
     use xcm_executor::traits::Convert as XcmConvert;
 
-    pub use crate::traits::*;
     use xcm_calls::{
         proxy::{ProxyCall, ProxyCallEncoder, ProxyConfig, ProxyParams, ProxyState, ProxyType},
         staking::{
@@ -116,6 +119,9 @@ pub mod pallet {
         type XcmSender: SendXcm;
 
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Asset registry with all the locations
+        type AssetRegistry: MultiAssetRegistry<Self::AssetId>;
 
         /// The weight for this pallet's extrinsics.
         type WeightInfo: WeightInfo;

--- a/pallets/remote-asset-manager/src/traits.rs
+++ b/pallets/remote-asset-manager/src/traits.rs
@@ -16,10 +16,10 @@ pub trait RemoteAssetManager<AccountId, AssetId, Balance> {
         amount: Balance,
     ) -> DispatchResult;
 
-    /// Dispatch XCM to bound assets
+    /// Dispatch XCM to bond assets
     fn bond(asset: AssetId, amount: Balance) -> DispatchResult;
 
-    /// Dispatch XCM to unbound assets
+    /// Dispatch XCM to unbond assets
     fn unbond(asset: AssetId, amount: Balance) -> DispatchResult;
 
     /// Ensures that the unbonding process succeeded

--- a/primitives/primitives/Cargo.toml
+++ b/primitives/primitives/Cargo.toml
@@ -24,6 +24,7 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'xcm/std',
 ]
 # this feature is only for compilation now
 runtime-benchmarks = []

--- a/primitives/primitives/Cargo.toml
+++ b/primitives/primitives/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+authors = ['ChainSafe Systems']
+description = 'Primitive types and traits for PINT.'
+edition = '2018'
+license = 'LGPL-3.0-only'
+name = 'primitives'
+readme = 'README.md'
+repository = 'https://github.com/ChainSafe/PINT/'
+version = '0.0.1'
+
+[dependencies]
+serde = { version = "1.0.101", features = ["derive"], optional = true }
+codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive'] }
+frame-support = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.4', default-features = false }
+frame-system = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.4', default-features = false }
+
+# Polkadot Dependencies
+xcm = { git = 'https://github.com/paritytech/polkadot', branch = 'release-v0.9.4' }
+
+[features]
+default = ['std']
+std = [
+    'serde',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+]
+# this feature is only for compilation now
+runtime-benchmarks = []
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']

--- a/primitives/primitives/Cargo.toml
+++ b/primitives/primitives/Cargo.toml
@@ -15,7 +15,7 @@ frame-support = { git = 'https://github.com/paritytech/substrate', branch = 'pol
 frame-system = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.4', default-features = false }
 
 # Polkadot Dependencies
-xcm = { git = 'https://github.com/paritytech/polkadot', branch = 'release-v0.9.4' }
+xcm = { git = 'https://github.com/paritytech/polkadot', branch = 'release-v0.9.4', default-features = false  }
 
 [features]
 default = ['std']

--- a/primitives/primitives/README.md
+++ b/primitives/primitives/README.md
@@ -1,0 +1,1 @@
+License: LGPL-3.0-only

--- a/primitives/primitives/src/lib.rs
+++ b/primitives/primitives/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+//! Primitive types used within PINT
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod traits;

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -1,0 +1,13 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+use xcm::v0::MultiLocation;
+
+/// Type that provides the mapping between `AssetId` and `MultiLocation`.
+pub trait MultiAssetRegistry<AssetId> {
+    /// Determines the relative location of the consensus system where the given asset is native from the point of view of the current system
+    fn native_asset_location(asset: &AssetId) -> Option<MultiLocation>;
+
+    /// Whether the given identifier is currently supported as a liquid asset
+    fn is_liquid_asset(asset: &AssetId) -> bool;
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,6 +80,7 @@ pallet-asset-index = {path = '../pallets/asset-index', default-features = false 
 pallet-saft-registry = {path = '../pallets/saft-registry', default-features = false }
 pallet-price-feed = {path = '../pallets/price-feed', default-features = false }
 pallet-remote-asset-manager = { path = '../pallets/remote-asset-manager', default-features = false }
+primitives = { path = '../primitives/primitives', default-features = false }
 
 xcm-calls = {path = '../primitives/xcm-calls', default-features = false }
 pallet-chainlink-feed = { git = 'https://github.com/ChainSafe/chainlink-polkadot', branch = 'upgrade-substrate-master', default-features = false }
@@ -141,6 +142,8 @@ std = [
 	'pallet-sudo/std',
 	'pallet-session/std',
 	'pallet-transaction-payment/std',
+	'primitives/std',
+
 	'parachain-info/std',
 	'cumulus-pallet-aura-ext/std',
 	'cumulus-pallet-parachain-system/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub use frame_support::{
     },
     PalletId, StorageValue,
 };
-use pallet_asset_index::{MultiAssetAdapter, MultiAssetRegistry};
+use pallet_asset_index::MultiAssetAdapter;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_committee::EnsureMember;
 pub use pallet_timestamp::Call as TimestampCall;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -756,6 +756,7 @@ impl pallet_remote_asset_manager::Config for Runtime {
     type AdminOrigin = frame_system::EnsureRoot<AccountId>;
     type XcmSender = XcmRouter;
     type Event = Event;
+    type AssetRegistry = AssetIndex;
     type WeightInfo = weights::pallet_remote_asset_manager::WeightInfo<Self>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,6 +59,7 @@ use pallet_asset_index::MultiAssetAdapter;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_committee::EnsureMember;
 pub use pallet_timestamp::Call as TimestampCall;
+use primitives::traits::MultiAssetRegistry;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Creates a new primtives crate for shared types/traits
- move the `MultiAssetRegistry` that is used by both the asset-index and remote-asset-manager
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Ref #116 