### PR TITLE
feat: optimise xcm asst management and monitor balances 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5462,6 +5462,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "orml-traits",
  "pallet-balances",
  "pallet-staking",
  "parity-scale-codec",
@@ -6910,7 +6911,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.5"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.5#3ce09da502dd74d88f24d76f579d19fd4e6c5624"
+source = "git+https://github.com/paritytech//polkadot?rev=3ce09da502dd74d88f24d76f579d19fd4e6c5624#3ce09da502dd74d88f24d76f579d19fd4e6c5624"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -6943,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.5"
-source = "git+https://github.com/paritytech//polkadot?rev=3ce09da502dd74d88f24d76f579d19fd4e6c5624#3ce09da502dd74d88f24d76f579d19fd4e6c5624"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.5#3ce09da502dd74d88f24d76f579d19fd4e6c5624"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -8565,10 +8566,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "sc-client-api",
- "sp-authorship 3.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5)",
+ "sp-authorship 3.0.0 (git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc)",
  "sp-runtime",
  "thiserror",
 ]
@@ -8576,10 +8577,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "sc-client-api",
- "sp-authorship 3.0.0 (git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc)",
+ "sp-authorship 3.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5)",
  "sp-runtime",
  "thiserror",
 ]
@@ -8789,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8808,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -9766,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9778,7 +9779,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10048,7 +10049,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10059,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech//substrate?rev=9c572625f6557dfdb19f47474369a0327d51dfbc#9c572625f6557dfdb19f47474369a0327d51dfbc"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.5#9c572625f6557dfdb19f47474369a0327d51dfbc"
 dependencies = [
  "lazy_static",
  "sp-core",

--- a/pallets/remote-asset-manager/Cargo.toml
+++ b/pallets/remote-asset-manager/Cargo.toml
@@ -32,6 +32,8 @@ xcm-calls = {path = "../../primitives/xcm-calls", default-features = false }
 primitives = { path = "../../primitives/primitives", default-features = false }
 xcm-assets = { path = "../../primitives/xcm-assets", default-features = false }
 
+orml-traits = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master', default-features = false }
+
 [dev-dependencies]
 sp-core = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.5', default-features = false }
 sp-io = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.5', default-features = false }
@@ -60,6 +62,8 @@ std = [
     'xcm-executor/std',
     'cumulus-pallet-xcm/std',
     'cumulus-primitives-core/std',
+
+    'orml-traits/std'
 ]
 # this feature is only for compilation now
 runtime-benchmarks = [

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -112,10 +112,16 @@ pub mod pallet {
         type RelayChainAssetId: Get<Self::AssetId>;
 
         /// The minimum amount that should be held in stash (must remain unbonded)
-        /// Withdrawals are only authorized if the updated stash balance does exceeds this
+        /// Withdrawals are only authorized if the updated stash balance does exceeds this.
+        ///
+        /// This must be at least the `ExistentialDeposit` as configured on the asset's
+        /// native chain (e.g. DOT/Polkadot)
         type MinimumRemoteStashBalance: GetByKey<Self::AssetId, Self::Balance>;
 
         /// Currency type for deposit/withdraw xcm assets
+        ///
+        /// NOTE: it is assumed that the total issuance/total balance of an asset
+        /// reflects the total balance of the PINT parachain account on the asset's native chain
         type Assets: MultiCurrency<
             Self::AccountId,
             CurrencyId = Self::AssetId,

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pallet {
     };
     use xcm_executor::traits::Convert as XcmConvert;
 
+    use orml_traits::{GetByKey, MultiCurrency};
     use xcm_assets::XcmAssetHandler;
     use xcm_calls::{
         proxy::{ProxyCall, ProxyCallEncoder, ProxyConfig, ProxyParams, ProxyState, ProxyType},
@@ -109,6 +110,17 @@ pub mod pallet {
         /// Identifier for the relay chain's specific asset
         #[pallet::constant]
         type RelayChainAssetId: Get<Self::AssetId>;
+
+        /// The minimum amount that should be held in stash (must remain unbonded)
+        /// Withdrawals are only authorized if the updated stash balance does exceeds this
+        type MinimumRemoteStashBalance: GetByKey<Self::AssetId, Self::Balance>;
+
+        /// Currency type for deposit/withdraw xcm assets
+        type Assets: MultiCurrency<
+            Self::AccountId,
+            CurrencyId = Self::AssetId,
+            Balance = Self::Balance,
+        >;
 
         /// Executor for cross chain messages.
         type XcmExecutor: ExecuteXcm<<Self as frame_system::Config>::Call>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -642,7 +642,8 @@ parameter_type_with_key! {
 // The minimum amount of assets that should remain unbonded.
 parameter_type_with_key! {
     pub MinimumRemoteStashBalance: |_asset_id: AssetId| -> Balance {
-        Zero::zero()
+        // Same as relaychain existential deposit
+        ExistentialDeposit::get()
     };
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -639,6 +639,13 @@ parameter_type_with_key! {
     };
 }
 
+// The minimum amount of assets that should remain unbonded.
+parameter_type_with_key! {
+    pub MinimumRemoteStashBalance: |_asset_id: AssetId| -> Balance {
+        Zero::zero()
+    };
+}
+
 impl orml_tokens::Config for Runtime {
     type Event = Event;
     type Balance = Balance;
@@ -763,6 +770,8 @@ impl pallet_remote_asset_manager::Config for Runtime {
     type SelfLocation = SelfLocation;
     type SelfParaId = parachain_info::Pallet<Runtime>;
     type RelayChainAssetId = RelayChainAssetId;
+    type MinimumRemoteStashBalance = MinimumRemoteStashBalance;
+    type Assets = Currencies;
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type XcmAssets = xcm_assets::XcmAssetExecutor<XcmAssetConfig>;
     // Using root as the admin origin for now


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- introduce the `MinimumRemoteStashBalance` type which is essentially a map (AssetId -> Balance) that determines the minimum amount of balance of a xcm asset should be kept in stash (unbonded) at all times.
- This must be at least the ExistentialDeposit as configured on the asset's native chain (e.g. DOT/Polkadot)
- This will restrict the amount the council can stake
- This will restrict asset withdrawals from PINT (xcm transfers) if the updated stash balance (of the PINT's parachain account) would fall below the configured threshold.

Note: 
* this does not prevent the user from redeeming PINT for assets, but potentially restricts withdrawals from PINT -> parachain/relaychain until the stash exceeds the threshold again.
* it is assumed that the total issuance/total balance of an asset reflects the total balance of the PINT parachain account on the asset's native chain


## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

Follow up tests after #154

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #128 