### PR TITLE
feat: extend asset recorder trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5507,6 +5507,8 @@ dependencies = [
  "orml-traits",
  "pallet-asset-index",
  "pallet-balances",
+ "pallet-price-feed",
+ "pallet-remote-asset-manager",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -641,13 +641,22 @@ pub mod pallet {
             T::Currency::transfer(asset_id, caller, &Self::treasury_account(), units)?;
 
             // register the asset
-            Assets::<T>::insert(asset_id, availability);
+            Self::insert_asset_availability(asset_id, availability);
 
             // increase the total issuance
             let issued = T::IndexToken::issue(nav);
             // add minted PINT to user's balance
             T::IndexToken::resolve_creating(&caller, issued);
             Ok(())
+        }
+
+        fn insert_asset_availability(
+            asset_id: T::AssetId,
+            availability: AssetAvailability,
+        ) -> Option<AssetAvailability> {
+            Assets::<T>::mutate(asset_id, |maybe_available| {
+                maybe_available.replace(availability)
+            })
         }
 
         fn remove_asset(_: &T::AssetId) -> DispatchResult {

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -682,7 +682,7 @@ pub mod pallet {
         }
 
         fn remove_asset(_: &T::AssetId) -> DispatchResult {
-            todo!();
+            Ok(())
         }
     }
 

--- a/pallets/asset-index/src/traits.rs
+++ b/pallets/asset-index/src/traits.rs
@@ -16,7 +16,10 @@ pub trait AssetRecorder<AccountId, AssetId, Balance> {
         availability: AssetAvailability,
     ) -> DispatchResult;
 
-
+    /// Mints the SAFT into the index and awards the caller with given amount of PINT token.
+    /// If an asset with the given AssetId does not already exist, it will be registered as SAFT.
+    /// Fails if the availability of the asset is liquid.
+    fn add_saft(caller: &AccountId, id: AssetId, units: Balance, nav: Balance) -> DispatchResult;
 
     /// Sets the availability of the given asset.
     /// If the asset was already registered, the old `AssetAvailability` is returned.

--- a/pallets/asset-index/src/traits.rs
+++ b/pallets/asset-index/src/traits.rs
@@ -16,6 +16,15 @@ pub trait AssetRecorder<AccountId, AssetId, Balance> {
         availability: AssetAvailability,
     ) -> DispatchResult;
 
+
+
+    /// Sets the availability of the given asset.
+    /// If the asset was already registered, the old `AssetAvailability` is returned.
+    fn insert_asset_availability(
+        asset_id: AssetId,
+        availability: AssetAvailability,
+    ) -> Option<AssetAvailability>;
+
     fn remove_asset(id: &AssetId) -> DispatchResult;
 }
 

--- a/pallets/saft-registry/Cargo.toml
+++ b/pallets/saft-registry/Cargo.toml
@@ -27,9 +27,13 @@ serde = { version = "1.0.101" }
 
 sp-core = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
 sp-io = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
 
-pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
+pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
+
+pallet-asset-index = { path = "../asset-index" }
+pallet-remote-asset-manager = { path = "../remote-asset-manager" }
+pallet-price-feed = { path = "../price-feed" }
 
 orml-tokens = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
 

--- a/pallets/saft-registry/src/lib.rs
+++ b/pallets/saft-registry/src/lib.rs
@@ -23,7 +23,7 @@ pub mod pallet {
     };
     use frame_system::pallet_prelude::*;
     use orml_traits::MultiCurrency;
-    use pallet_asset_index::traits::{AssetAvailability, AssetRecorder};
+    use pallet_asset_index::traits::AssetRecorder;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -112,16 +112,8 @@ pub mod pallet {
             T::AdminOrigin::ensure_origin(origin.clone())?;
             let caller = ensure_signed(origin)?;
 
-            // mint SAFT first that get transferred into the index in the next step
-            T::Currency::deposit(asset_id, &caller, units)?;
-
-            <T as Config>::AssetRecorder::add_asset(
-                &caller,
-                asset_id,
-                units,
-                nav.clone(),
-                AssetAvailability::Saft,
-            )?;
+            // mint SAFT units into the index and credit the caller's account with PINT
+            <T as Config>::AssetRecorder::add_saft(&caller, asset_id, units, nav.clone())?;
 
             let index = ActiveSAFTs::<T>::mutate(asset_id, |records| {
                 let index = records.len() as u32;

--- a/pallets/saft-registry/src/mock.rs
+++ b/pallets/saft-registry/src/mock.rs
@@ -5,10 +5,12 @@
 #![allow(clippy::from_over_into)]
 
 use crate as pallet_saft_registry;
-use frame_support::{ord_parameter_types, parameter_types};
+use frame_support::{ord_parameter_types, parameter_types, traits::StorageMapShim, PalletId};
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
-use pallet_asset_index::traits::{AssetAvailability, AssetRecorder};
+use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
+use pallet_remote_asset_manager::RemoteAssetManager;
+use sp_runtime::DispatchResult;
 
 use sp_core::H256;
 use sp_runtime::{
@@ -29,6 +31,8 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
         SaftRegistry: pallet_saft_registry::{Pallet, Call, Storage, Event<T>},
+        AssetIndex: pallet_asset_index::{Pallet, Call, Storage, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
         Currency: orml_tokens::{Pallet, Event<T>},
     }
 );
@@ -36,13 +40,13 @@ frame_support::construct_runtime!(
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
-    pub const MaxLocks: u32 = 1024;
 }
 
-pub(crate) type Balance = u64;
-pub(crate) type Amount = i64;
+pub(crate) type Balance = u128;
+pub(crate) type Amount = i128;
 pub(crate) type AccountId = u64;
 pub(crate) type AssetId = u32;
+pub(crate) type BlockNumber = u64;
 
 impl system::Config for Test {
     type BaseCallFilter = ();
@@ -52,7 +56,7 @@ impl system::Config for Test {
     type Origin = Origin;
     type Call = Call;
     type Index = u64;
-    type BlockNumber = u64;
+    type BlockNumber = BlockNumber;
     type Hash = H256;
     type Hashing = BlakeTwo256;
     type AccountId = AccountId;
@@ -68,6 +72,92 @@ impl system::Config for Test {
     type SystemWeightInfo = ();
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
+}
+
+// param types for balances
+parameter_types! {
+    pub const MaxLocks: u32 = 1024;
+    pub static ExistentialDeposit: Balance = 0;
+}
+
+impl pallet_balances::Config for Test {
+    type Balance = Balance;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = StorageMapShim<
+        pallet_balances::Account<Test>,
+        system::Provider<Test>,
+        AccountId,
+        pallet_balances::AccountData<Balance>,
+    >;
+    type MaxLocks = MaxLocks;
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub LockupPeriod: <Test as system::Config>::BlockNumber = 10;
+    pub MinimumRedemption: u32 = 2;
+    pub WithdrawalPeriod: <Test as system::Config>::BlockNumber = 10;
+    pub DOTContributionLimit: Balance = 999;
+    pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
+    pub StringLimit: u32 = 4;
+}
+
+impl pallet_asset_index::Config for Test {
+    type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
+    type Event = Event;
+    type AssetId = AssetId;
+    type IndexToken = Balances;
+    type Balance = Balance;
+    type LockupPeriod = LockupPeriod;
+    type MinimumRedemption = MinimumRedemption;
+    type WithdrawalPeriod = WithdrawalPeriod;
+    type DOTContributionLimit = DOTContributionLimit;
+    type RemoteAssetManager = MockRemoteAssetManager;
+    type Currency = Currency;
+    type PriceFeed = MockPriceFeed;
+    type TreasuryPalletId = TreasuryPalletId;
+    type StringLimit = StringLimit;
+    type WithdrawalFee = ();
+    type WeightInfo = ();
+}
+
+pub struct MockRemoteAssetManager;
+impl<AccountId, AssetId, Balance> RemoteAssetManager<AccountId, AssetId, Balance>
+    for MockRemoteAssetManager
+{
+    fn transfer_asset(_: AccountId, _: AssetId, _: Balance) -> DispatchResult {
+        Ok(())
+    }
+
+    fn bond(_: AssetId, _: Balance) -> DispatchResult {
+        Ok(())
+    }
+
+    fn unbond(_: AssetId, _: Balance) -> DispatchResult {
+        Ok(())
+    }
+}
+
+pub struct MockPriceFeed;
+impl PriceFeed<AssetId> for MockPriceFeed {
+    fn get_price(_quote: AssetId) -> Result<AssetPricePair<AssetId>, DispatchError> {
+        todo!()
+    }
+
+    fn get_price_pair(
+        _base: AssetId,
+        _quote: AssetId,
+    ) -> Result<AssetPricePair<AssetId>, DispatchError> {
+        todo!()
+    }
+
+    fn ensure_price(_: AssetId, _: Price) -> Result<AssetPricePair<AssetId>, DispatchError> {
+        todo!()
+    }
 }
 
 parameter_type_with_key! {
@@ -92,28 +182,11 @@ ord_parameter_types! {
     pub const AdminAccountId: AccountId = ADMIN_ACCOUNT_ID;
 }
 
-pub struct MockAssetRecorder;
-
-impl<AssetId, Balance> AssetRecorder<AccountId, AssetId, Balance> for MockAssetRecorder {
-    fn add_asset(
-        _: &AccountId,
-        _: AssetId,
-        _: Balance,
-        _: Balance,
-        _: AssetAvailability,
-    ) -> Result<(), DispatchError> {
-        Ok(())
-    }
-    fn remove_asset(_: &AssetId) -> Result<(), DispatchError> {
-        Ok(())
-    }
-}
-
 impl pallet_saft_registry::Config for Test {
     type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
     type Event = Event;
     type Balance = Balance;
-    type AssetRecorder = MockAssetRecorder;
+    type AssetRecorder = AssetIndex;
     type AssetId = AssetId;
     type Currency = Currency;
     type WeightInfo = ();

--- a/pallets/saft-registry/src/tests.rs
+++ b/pallets/saft-registry/src/tests.rs
@@ -30,14 +30,25 @@ fn non_admin_cannot_call_any_extrinsics() {
 
 #[test]
 fn admin_can_add_and_remove_saft() {
+    let units = 20;
+    let nav = 100;
     new_test_ext().execute_with(|| {
         // add
         assert_ok!(SaftRegistry::add_saft(
             Origin::signed(ADMIN_ACCOUNT_ID),
             ASSET_A,
-            100,
-            20
+            nav,
+            units
         ));
+        assert_eq!(
+            super::ActiveSAFTs::<Test>::get(ASSET_A),
+            vec![SAFTRecord::new(nav, units)]
+        );
+        assert_eq!(AssetIndex::index_total_asset_balance(ASSET_A), units);
+        assert_eq!(Balances::free_balance(ADMIN_ACCOUNT_ID), nav);
+        assert_eq!(AssetIndex::index_token_balance(&ADMIN_ACCOUNT_ID), nav);
+        assert_eq!(AssetIndex::index_token_issuance(), nav);
+
         assert_eq!(
             super::ActiveSAFTs::<Test>::get(ASSET_A),
             vec![SAFTRecord::new(100, 20)]


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- extend the `AssetRecorder` trait with a standalone `set_availiabiliy` function 
- add designated support for `add_saft` that directly mints SAFT and PINT and fails if AssetId is liquid.
- update some tests.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #162 