### PR TITLE
feat: add register asset extrinsic

### DIFF
--- a/pallets/asset-index/src/traits.rs
+++ b/pallets/asset-index/src/traits.rs
@@ -3,19 +3,11 @@
 
 pub use crate::types::{AssetAvailability, AssetMetadata};
 use frame_support::{dispatch::DispatchResult, sp_runtime::traits::AtLeast32BitUnsigned};
-use xcm::v0::MultiLocation;
 
 pub trait AssetRecorder<AccountId, AssetId, Balance> {
     /// Add an liquid asset into the index.
-    /// If an asset with the given AssetId does not already exist, it will be registered.
     /// This moves the given units from the caller's balance into the index's and issues PINT accordingly.
-    fn add_liquid(
-        caller: &AccountId,
-        id: AssetId,
-        units: Balance,
-        nav: Balance,
-        location: MultiLocation,
-    ) -> DispatchResult;
+    fn add_liquid(caller: &AccountId, id: AssetId, units: Balance, nav: Balance) -> DispatchResult;
 
     /// Mints the SAFT into the index and awards the caller with given amount of PINT token.
     /// If an asset with the given AssetId does not already exist, it will be registered as SAFT.


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Adds another extrinsic to register new assets

We could also think about dropping the `location` parameter of the `add_asset` in favor of this new extrinsic?

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #179