### PR TITLE
fix: disallow native asset deposits and withdrawals

### DIFF
--- a/pallets/asset-index/src/mock.rs
+++ b/pallets/asset-index/src/mock.rs
@@ -130,12 +130,14 @@ parameter_types! {
     pub DOTContributionLimit: Balance = 999;
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
     pub StringLimit: u32 = 4;
+    pub const PINTAssetId: AssetId = PINT_ASSET_ID;
 }
 
 impl pallet_asset_index::Config for Test {
     type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
     type Event = Event;
     type AssetId = AssetId;
+    type SelfAssetId = PINTAssetId;
     type IndexToken = Balances;
     type Balance = Balance;
     type LockupPeriod = LockupPeriod;

--- a/pallets/asset-index/src/tests.rs
+++ b/pallets/asset-index/src/tests.rs
@@ -68,6 +68,22 @@ fn admin_can_add_asset() {
 }
 
 #[test]
+fn native_asset_disallowed() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            AssetIndex::add_asset(
+                Origin::signed(ADMIN_ACCOUNT_ID),
+                PINT_ASSET_ID,
+                100,
+                MultiLocation::Null,
+                5
+            ),
+            pallet::Error::<Test>::NativeAssetDisallowed
+        );
+    });
+}
+
+#[test]
 fn admin_can_add_asset_twice_and_units_accumulate() {
     new_test_ext().execute_with(|| {
         assert_ok!(AssetIndex::add_asset(
@@ -164,6 +180,16 @@ fn deposit_only_works_for_added_liquid_assets() {
         assert_noop!(
             AssetIndex::deposit(Origin::signed(ASHLEY), ASSET_A_ID, 1_000),
             pallet::Error::<Test>::UnsupportedAsset
+        );
+    });
+}
+
+#[test]
+fn deposit_fail_for_native_asset() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            AssetIndex::deposit(Origin::signed(ASHLEY), PINT_ASSET_ID, 1_000),
+            pallet::Error::<Test>::NativeAssetDisallowed
         );
     });
 }

--- a/pallets/saft-registry/src/mock.rs
+++ b/pallets/saft-registry/src/mock.rs
@@ -104,12 +104,14 @@ parameter_types! {
     pub DOTContributionLimit: Balance = 999;
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
     pub StringLimit: u32 = 4;
+    pub const PINTAssetId: AssetId = 99;
 }
 
 impl pallet_asset_index::Config for Test {
     type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
     type Event = Event;
     type AssetId = AssetId;
+    type SelfAssetId = PINTAssetId;
     type IndexToken = Balances;
     type Balance = Balance;
     type LockupPeriod = LockupPeriod;

--- a/pallets/saft-registry/src/tests.rs
+++ b/pallets/saft-registry/src/tests.rs
@@ -29,6 +29,16 @@ fn non_admin_cannot_call_any_extrinsics() {
 }
 
 #[test]
+fn native_asset_disallowed() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            SaftRegistry::add_saft(Origin::signed(ADMIN_ACCOUNT_ID), PINTAssetId::get(), 0, 0),
+            pallet_asset_index::Error::<Test>::NativeAssetDisallowed
+        );
+    });
+}
+
+#[test]
 fn admin_can_add_and_remove_saft() {
     let units = 20;
     let nav = 100;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -586,6 +586,7 @@ impl pallet_asset_index::Config for Runtime {
     type AdminOrigin = frame_system::EnsureSigned<AccountId>;
     type Event = Event;
     type AssetId = AssetId;
+    type SelfAssetId = PINTAssetId;
     type IndexToken = Balances;
     type Balance = Balance;
     type LockupPeriod = LockupPeriod;


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Ensures the given asset is not the native asset for operations that expect liquid / saft

This would probably be caught as well by the `ensure_liquid_asset` function but this way it's handled explicitly.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #191