### PR TITLE
perf(asset-index): explicit arguments of add_asset and deposit

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -224,6 +224,8 @@ pub mod pallet {
         NoPendingWithdrawals,
         /// Thrown if the asset that should be added is already registered
         AssetAlreadyExists,
+        /// Thrown when adding assets with zero amount or units
+        InvalidPrice,
     }
 
     #[pallet::hooks]
@@ -243,7 +245,7 @@ pub mod pallet {
             asset_id: T::AssetId,
             units: T::Balance,
             location: MultiLocation,
-            value: T::Balance,
+            amount: T::Balance,
         ) -> DispatchResultWithPostInfo {
             T::AdminOrigin::ensure_origin(origin.clone())?;
             let caller = ensure_signed(origin)?;
@@ -259,12 +261,17 @@ pub mod pallet {
             };
 
             // transfer the caller's fund into the treasury account
-            Self::add_liquid(&caller, asset_id, units, value)?;
+            Self::add_liquid(&caller, asset_id, units, amount)?;
 
             // Store initial price pair if not exists
             T::PriceFeed::ensure_price(
                 asset_id,
-                Price::from_inner(value.saturating_mul(units).into()),
+                Price::from_inner(
+                    amount
+                        .checked_div(&units)
+                        .ok_or(<Error<T>>::InvalidPrice)?
+                        .into(),
+                ),
             )?;
 
             // register asset if not yet known
@@ -273,7 +280,7 @@ pub mod pallet {
                 Self::deposit_event(Event::AssetRegistered(asset_id, availability));
             }
 
-            Self::deposit_event(Event::AssetAdded(asset_id, units, caller, value));
+            Self::deposit_event(Event::AssetAdded(asset_id, units, caller, amount));
             Ok(().into())
         }
 
@@ -387,7 +394,7 @@ pub mod pallet {
         pub fn deposit(
             origin: OriginFor<T>,
             asset_id: T::AssetId,
-            amount: T::Balance,
+            units: T::Balance,
         ) -> DispatchResultWithPostInfo {
             let caller = ensure_signed(origin)?;
 
@@ -397,7 +404,7 @@ pub mod pallet {
             // only liquid assets can be deposited
             Self::ensure_liquid_asset(&asset_id)?;
 
-            let pint_amount = Self::calculate_pint_equivalent(asset_id, amount)?;
+            let pint_amount = Self::calculate_pint_equivalent(asset_id, units)?;
 
             // transfer from the caller's sovereign account into the treasury's account
             T::Currency::transfer(asset_id, &caller, &Self::treasury_account(), amount)?;

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -407,14 +407,14 @@ pub mod pallet {
             let pint_amount = Self::calculate_pint_equivalent(asset_id, units)?;
 
             // transfer from the caller's sovereign account into the treasury's account
-            T::Currency::transfer(asset_id, &caller, &Self::treasury_account(), amount)?;
+            T::Currency::transfer(asset_id, &caller, &Self::treasury_account(), units)?;
 
             // increase the total issuance
             let issued = T::IndexToken::issue(pint_amount);
 
             // add minted PINT to user's balance
             T::IndexToken::resolve_creating(&caller, issued);
-            Self::deposit_event(Event::Deposited(asset_id, amount, caller, pint_amount));
+            Self::deposit_event(Event::Deposited(asset_id, units, caller, pint_amount));
             Ok(().into())
         }
 


### PR DESCRIPTION
## Changes

- use `amount` instead of `value` in `add_asset`
- use `units` instead of `amount` in `deposit`


## Tests


```
CI
```

## Issues

-