### PR TITLE
refactor: withdrawal fee model

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -51,6 +51,7 @@ pub mod pallet {
         AssetAvailability, AssetMetadata, AssetWithdrawal, PendingRedemption, RedemptionState,
     };
     use primitives::traits::{MultiAssetRegistry, RemoteAssetManager};
+    use primitives::fee::Fee;
 
     type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 
@@ -105,6 +106,10 @@ pub mod pallet {
 
         /// The type that calculates the withdrawal fee
         type WithdrawalFee: WithdrawalFee<Self::Balance>;
+
+        /// The basic fees that apply when a withdrawal is executed
+        #[pallet::constant]
+        type BaseWithdrawalFee: Get<Fee>;
 
         /// The treasury's pallet id, used for deriving its sovereign account ID.
         #[pallet::constant]

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -45,13 +45,12 @@ pub mod pallet {
     use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
 
     pub use crate::traits::AssetRecorder;
-    use crate::traits::WithdrawalFee;
     pub use crate::types::MultiAssetAdapter;
     use crate::types::{
         AssetAvailability, AssetMetadata, AssetWithdrawal, PendingRedemption, RedemptionState,
     };
+    use primitives::fee::{BaseFee, FeeRate};
     use primitives::traits::{MultiAssetRegistry, RemoteAssetManager};
-    use primitives::fee::Fee;
 
     type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 
@@ -70,7 +69,8 @@ pub mod pallet {
             + Default
             + Copy
             + MaybeSerializeDeserialize
-            + Into<u128>;
+            + Into<u128>
+            + BaseFee;
         /// Period after the minting of the index token for which 100% is locked up.
         /// Only applies to users contributing assets directly to index
         #[pallet::constant]
@@ -104,12 +104,9 @@ pub mod pallet {
         /// The types that provides the necessary asset price pairs
         type PriceFeed: PriceFeed<Self::AssetId>;
 
-        /// The type that calculates the withdrawal fee
-        type WithdrawalFee: WithdrawalFee<Self::Balance>;
-
         /// The basic fees that apply when a withdrawal is executed
         #[pallet::constant]
-        type BaseWithdrawalFee: Get<Fee>;
+        type BaseWithdrawalFee: Get<FeeRate>;
 
         /// The treasury's pallet id, used for deriving its sovereign account ID.
         #[pallet::constant]
@@ -453,7 +450,9 @@ pub mod pallet {
                 free_balance.saturating_sub(amount),
             )?;
 
-            let fee = T::WithdrawalFee::withdrawal_fee(amount);
+            let fee = amount
+                .fee(T::BaseWithdrawalFee::get())
+                .ok_or(Error::<T>::AssetUnitsOverflow)?;
             let redeem = amount
                 .checked_sub(&fee)
                 .ok_or(Error::<T>::InsufficientDeposit)?

--- a/pallets/asset-index/src/mock.rs
+++ b/pallets/asset-index/src/mock.rs
@@ -15,7 +15,7 @@ use frame_support::{
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
 use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
-use primitives::traits::RemoteAssetManager;
+use primitives::{fee::FeeRate, traits::RemoteAssetManager};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
@@ -131,6 +131,9 @@ parameter_types! {
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
     pub StringLimit: u32 = 4;
     pub const PINTAssetId: AssetId = PINT_ASSET_ID;
+
+    // No fees for now
+    pub const BaseWithdrawalFee: FeeRate = FeeRate{ numerator: 0, denominator: 1_000,};
 }
 
 impl pallet_asset_index::Config for Test {
@@ -149,7 +152,7 @@ impl pallet_asset_index::Config for Test {
     type PriceFeed = MockPriceFeed;
     type TreasuryPalletId = TreasuryPalletId;
     type StringLimit = StringLimit;
-    type WithdrawalFee = ();
+    type BaseWithdrawalFee = BaseWithdrawalFee;
     type WeightInfo = ();
 }
 

--- a/pallets/remote-asset-manager/src/mock.rs
+++ b/pallets/remote-asset-manager/src/mock.rs
@@ -375,6 +375,9 @@ pub mod para {
         pub const RelayChainAssetId: AssetId = RELAY_CHAIN_ASSET;
         pub const PINTAssetId: AssetId = PARA_ASSET;
         pub SelfLocation: MultiLocation = MultiLocation::X2(Junction::Parent, Junction::Parachain(ParachainInfo::parachain_id().into()));
+
+         // No fees for now
+        pub const BaseWithdrawalFee: primitives::fee::FeeRate = primitives::fee::FeeRate{ numerator: 0, denominator: 1_000,};
     }
 
     ord_parameter_types! {
@@ -397,7 +400,7 @@ pub mod para {
         type PriceFeed = MockPriceFeed;
         type TreasuryPalletId = TreasuryPalletId;
         type StringLimit = StringLimit;
-        type WithdrawalFee = ();
+        type BaseWithdrawalFee = BaseWithdrawalFee;
         type WeightInfo = ();
     }
 

--- a/pallets/saft-registry/src/mock.rs
+++ b/pallets/saft-registry/src/mock.rs
@@ -105,6 +105,9 @@ parameter_types! {
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
     pub StringLimit: u32 = 4;
     pub const PINTAssetId: AssetId = 99;
+
+    // No fees for now
+    pub const BaseWithdrawalFee: primitives::fee::FeeRate = primitives::fee::FeeRate{ numerator: 0, denominator: 1_000,};
 }
 
 impl pallet_asset_index::Config for Test {
@@ -123,7 +126,7 @@ impl pallet_asset_index::Config for Test {
     type PriceFeed = MockPriceFeed;
     type TreasuryPalletId = TreasuryPalletId;
     type StringLimit = StringLimit;
-    type WithdrawalFee = ();
+    type BaseWithdrawalFee = BaseWithdrawalFee;
     type WeightInfo = ();
 }
 

--- a/primitives/primitives/src/lib.rs
+++ b/primitives/primitives/src/lib.rs
@@ -50,23 +50,62 @@ pub type FeedId = u64;
 pub type Value = u128;
 
 pub mod fee {
-    use codec::{Encode, Decode};
+    use codec::{Decode, Encode};
 
     /// Represents the fee rate where fee_rate = numerator / denominator
     #[derive(Debug, Encode, Decode, Copy, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Fee {
+    pub struct FeeRate {
         pub numerator: u32,
         pub denominator: u32,
     }
 
-    impl Default for Fee {
+    impl Default for FeeRate {
         fn default() -> Self {
             // 0.3%
             Self {
                 numerator: 3,
-                denominator: 1_000
+                denominator: 1_000,
             }
+        }
+    }
+
+    pub trait BaseFee
+    where
+        Self: Sized,
+    {
+        /// Returns the given amount after applying the fee rate: `self - fee`
+        fn without_fee(&self, rate: FeeRate) -> Option<Self>;
+
+        /// Returns the fees only.
+        fn fee(&self, rate: FeeRate) -> Option<Self>;
+    }
+
+    impl BaseFee for super::Balance {
+        fn without_fee(&self, rate: FeeRate) -> Option<Self> {
+            self.checked_mul(rate.denominator as Self)?
+                .checked_div(rate.denominator as Self + rate.numerator as Self)
+        }
+
+        fn fee(&self, rate: FeeRate) -> Option<Self> {
+            self.checked_mul(rate.numerator as Self)?
+                .checked_div(rate.denominator as Self)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_fee_calculations() {
+            let rate = FeeRate {
+                numerator: 3,
+                denominator: 1_000,
+            };
+
+            assert_eq!(1_003.without_fee(rate), Some(1_000));
+            assert_eq!(1_003.fee(rate), Some(3));
         }
     }
 }

--- a/primitives/primitives/src/lib.rs
+++ b/primitives/primitives/src/lib.rs
@@ -48,3 +48,25 @@ pub type FeedId = u64;
 
 /// Value type for price feeds.
 pub type Value = u128;
+
+pub mod fee {
+    use codec::{Encode, Decode};
+
+    /// Represents the fee rate where fee_rate = numerator / denominator
+    #[derive(Debug, Encode, Decode, Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+    pub struct Fee {
+        pub numerator: u32,
+        pub denominator: u32,
+    }
+
+    impl Default for Fee {
+        fn default() -> Self {
+            // 0.3%
+            Self {
+                numerator: 3,
+                denominator: 1_000
+            }
+        }
+    }
+}

--- a/resources/types.json
+++ b/resources/types.json
@@ -28,6 +28,10 @@
   },
   "CurrencyId": "AssetId",
   "CurrencyIdOf": "CurrencyId",
+  "FeeRate": {
+    "numerator": "u32",
+    "denominator": "u32"
+  },
   "HashFor": "Hash",
   "IndexAssetData": {
     "units": "Balance",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -64,8 +64,8 @@ pub use frame_support::{
 pub use pallet_balances::Call as BalancesCall;
 use pallet_committee::EnsureMember;
 pub use pallet_timestamp::Call as TimestampCall;
-use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
+use primitives::{fee::FeeRate, traits::MultiAssetRegistry};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
@@ -584,6 +584,9 @@ parameter_types! {
     pub WithdrawalPeriod: <Runtime as frame_system::Config>::BlockNumber = 10;
     pub DOTContributionLimit: Balance = 999;
     pub PalletIndexStringLimit: u32 = 50;
+
+    // TODO: use actual fees
+    pub const BaseWithdrawalFee: FeeRate = FeeRate{ numerator: 0, denominator: 1_000,};
 }
 
 impl pallet_asset_index::Config for Runtime {
@@ -602,7 +605,7 @@ impl pallet_asset_index::Config for Runtime {
     type Currency = Currencies;
     type PriceFeed = PriceFeed;
     type TreasuryPalletId = TreasuryPalletId;
-    type WithdrawalFee = ();
+    type BaseWithdrawalFee = BaseWithdrawalFee;
     type StringLimit = PalletIndexStringLimit;
     type WeightInfo = weights::pallet_asset_index::WeightInfo<Self>;
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Adds a fixed fee type for withdrawals, from there the final fee should be a configurable function based on the time the assets remained in the index but this needs some further work on how deposits are tracked first.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #206