### PR TITLE
fix(remote-asset-manager): the usages of runtime-benchmarks feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,12 +5116,8 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "pallet-balances",
  "parity-scale-codec",
- "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
 ]
 
 [[package]]

--- a/pallets/committee/Cargo.toml
+++ b/pallets/committee/Cargo.toml
@@ -9,38 +9,27 @@ repository = 'https://github.com/ChainSafe/PINT/'
 version = '0.0.1'
 
 [dependencies]
-serde = { version = "1.0.101", optional = true }
 codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive']}
 
 # Substrate Dependencies
 frame-support = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
 frame-system = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false, optional = true }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false, optional = true }
-
 
 [dev-dependencies]
 sp-core = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
-sp-io = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
-
-pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', default-features = false }
-
 
 [features]
 default = ['std']
 std = [
     'codec/std',
-    'serde',
     'frame-support/std',
     'frame-system/std',
-    'sp-runtime/std',
 ]
 runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'frame-system/runtime-benchmarks',
-    'sp-runtime/runtime-benchmarks',
 ]
 
 [package.metadata.docs.rs]

--- a/pallets/committee/src/mock.rs
+++ b/pallets/committee/src/mock.rs
@@ -8,16 +8,16 @@ use crate::{self as pallet_committee, EnsureMember};
 #[cfg(feature = "std")]
 use frame_support::traits::GenesisBuild;
 use frame_support::{
-    ord_parameter_types, parameter_types,
+    ord_parameter_types, parameter_types, sp_io,
+    sp_runtime::{
+        testing::Header,
+        traits::{BlakeTwo256, IdentityLookup},
+    },
     traits::{OnFinalize, OnInitialize},
 };
 use frame_system::{self as system, EnsureSignedBy};
 
 use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/committee/src/tests.rs
+++ b/pallets/committee/src/tests.rs
@@ -4,9 +4,8 @@
 use crate as pallet;
 use crate::mock::*;
 use crate::{CommitteeMember, MemberType, Vote, VoteAggregate};
-use frame_support::{assert_noop, assert_ok, codec::Encode};
+use frame_support::{assert_noop, assert_ok, codec::Encode, sp_runtime::traits::BadOrigin};
 use frame_system as system;
-use sp_runtime::traits::BadOrigin;
 use std::convert::{TryFrom, TryInto};
 
 const ASHLEY: AccountId = 0;

--- a/pallets/committee/src/types.rs
+++ b/pallets/committee/src/types.rs
@@ -10,9 +10,6 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
-
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 /// This represents an instance of a proposal that can be voted on.
 /// It has been proposed and has an assigned nonce.
@@ -31,7 +28,6 @@ impl<T: Config> Proposal<T> {
 }
 
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 /// Defines what sub-type a member belongs to.
 /// Council members are fixed in number and can vote on proposals
 /// Constituent members are unbounded in number but can only veto council proposals

--- a/pallets/remote-asset-manager/Cargo.toml
+++ b/pallets/remote-asset-manager/Cargo.toml
@@ -54,7 +54,7 @@ pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = 'p
 pallet-staking-reward-curve = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
 pallet-timestamp = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
 pallet-session = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
-pallet-collective = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7', features = ['runtime-benchmarks'] }
+pallet-collective = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.7' }
 
 # cumulus
 cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.7" }
@@ -65,10 +65,10 @@ cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.7" }
 
 # polkadot
-xcm-builder = { git = 'https://github.com/paritytech/polkadot', branch = 'release-v0.9.7', features = ['runtime-benchmarks'] }
+xcm-builder = { git = 'https://github.com/paritytech/polkadot', branch = 'release-v0.9.7' }
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.7" }
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.7" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.7", features = ['runtime-benchmarks'] }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.7" }
 
 # PINT
 pallet-asset-index = {path = "../asset-index" }
@@ -109,6 +109,10 @@ runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'frame-system/runtime-benchmarks',
+    'pallet-collective/runtime-benchmarks',
+    # polkadot
+    'xcm-builder/runtime-benchmarks',
+    'pallet-xcm/runtime-benchmarks'
 ]
 
 [package.metadata.docs.rs]

--- a/pallets/remote-asset-manager/Cargo.toml
+++ b/pallets/remote-asset-manager/Cargo.toml
@@ -109,10 +109,6 @@ runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'frame-system/runtime-benchmarks',
-    'pallet-collective/runtime-benchmarks',
-    # polkadot
-    'xcm-builder/runtime-benchmarks',
-    'pallet-xcm/runtime-benchmarks'
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Changes

Could not build with `cargo build --release` because of using `runtime-features` directly in `Cargo.toml`

## Tests

```
CI
```

## Issues

Closes #208 