### PR TITLE
feat: lock freshly minted index token up for lockup period

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -815,7 +815,7 @@ pub mod pallet {
             let locks = locks
                 .into_iter()
                 .filter(|lock| {
-                    if current_block > lock.end_block {
+                    if current_block >= lock.end_block {
                         // lock period is over
                         false
                     } else {
@@ -826,16 +826,23 @@ pub mod pallet {
                 })
                 .collect::<Vec<_>>();
 
-            // set the lock, if it already exists, this will update it
-            T::IndexToken::set_lock(
-                T::IndexTokenLockIdentifier::get(),
-                user,
-                locked,
-                WithdrawReasons::all(),
-            );
+            if locks.is_empty() {
+                // remove the lock entirely
+                T::IndexToken::remove_lock(T::IndexTokenLockIdentifier::get(), user);
+                IndexTokenLocks::<T>::remove(user);
+                LockedIndexToken::<T>::remove(user);
+            } else {
+                // set the lock, if it already exists, this will update it
+                T::IndexToken::set_lock(
+                    T::IndexTokenLockIdentifier::get(),
+                    user,
+                    locked,
+                    WithdrawReasons::all(),
+                );
 
-            IndexTokenLocks::<T>::insert(user, locks);
-            LockedIndexToken::<T>::insert(user, locked);
+                IndexTokenLocks::<T>::insert(user, locks);
+                LockedIndexToken::<T>::insert(user, locked);
+            }
         }
 
         /// Updates the index token locks for the given user.

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -35,7 +35,9 @@ pub mod pallet {
             FixedPointNumber, FixedU128,
         },
         sp_std::{convert::TryInto, prelude::*, result::Result},
-        traits::{Currency, ExistenceRequirement, Get, LockableCurrency, WithdrawReasons, LockIdentifier},
+        traits::{
+            Currency, ExistenceRequirement, Get, LockIdentifier, LockableCurrency, WithdrawReasons,
+        },
         PalletId,
     };
     use frame_system::pallet_prelude::*;
@@ -46,7 +48,10 @@ pub mod pallet {
 
     pub use crate::traits::AssetRecorder;
     pub use crate::types::MultiAssetAdapter;
-    use crate::types::{AssetAvailability, AssetMetadata, AssetWithdrawal, PendingRedemption, RedemptionState, IndexTokenLockInfo};
+    use crate::types::{
+        AssetAvailability, AssetMetadata, AssetWithdrawal, IndexTokenLock, PendingRedemption,
+        RedemptionState,
+    };
     use primitives::fee::{BaseFee, FeeRate};
     use primitives::traits::{MultiAssetRegistry, RemoteAssetManager};
 
@@ -144,15 +149,22 @@ pub mod pallet {
     >;
 
     #[pallet::storage]
+    /// Tracks the locks of the minted index token that are locked up until their `LockupPeriod` is over
     ///  (AccountId) -> Vec<IndexTokenLockInfo>
-    /// tracks the minted index token that are locked up until their `LockupPeriod` is over
     pub type IndexTokenLocks<T: Config> = StorageMap<
         _,
         Blake2_128Concat,
         T::AccountId,
-        Vec<IndexTokenLockInfo<T::BlockNumber, T::Balance>>,
-        OptionQuery,
+        Vec<IndexTokenLock<T::BlockNumber, T::Balance>>,
+        ValueQuery,
     >;
+
+    #[pallet::storage]
+    /// Tracks the amount of the currently locked index token per user.
+    /// This is equal to the sum(IndexTokenLocks[AccountId])
+    ///  (AccountId) -> Balance
+    pub type LockedIndexToken<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, T::Balance, ValueQuery>;
 
     #[pallet::storage]
     /// Metadata of an asset ( for reversed usage now ).
@@ -428,11 +440,9 @@ pub mod pallet {
             // transfer from the caller's sovereign account into the treasury's account
             T::Currency::transfer(asset_id, &caller, &Self::treasury_account(), units)?;
 
-            // increase the total issuance
-            let issued = T::IndexToken::issue(pint_amount);
+            // mint index token in caller's account
+            Self::do_mint_index_token(&caller, pint_amount);
 
-            // add minted PINT to user's balance
-            T::IndexToken::resolve_creating(&caller, issued);
             Self::deposit_event(Event::Deposited(asset_id, units, caller, pint_amount));
             Ok(().into())
         }
@@ -758,6 +768,59 @@ pub mod pallet {
                 Error::<T>::NativeAssetDisallowed
             );
             Ok(())
+        }
+
+        /// Mints the given amount of index token into the user's account and updates the lock accordingly
+        fn do_mint_index_token(user: &T::AccountId, amount: T::Balance) {
+            // increase the total issuance
+            let issued = T::IndexToken::issue(amount);
+            // add minted PINT to user's free balance
+            T::IndexToken::resolve_creating(user, issued);
+
+            Self::do_add_index_token_lock(user, amount);
+        }
+
+        /// Locks up the given amount of index token according to the `LockupPeriod` and updates the existing locks
+        fn do_add_index_token_lock(user: &T::AccountId, amount: T::Balance) {
+            let current_block = frame_system::Pallet::<T>::block_number();
+            let mut locks = IndexTokenLocks::<T>::get(user);
+            locks.push(IndexTokenLock {
+                locked: amount,
+                end_block: current_block + T::LockupPeriod::get(),
+            });
+        }
+
+        fn do_update_locks(
+            user: &T::AccountId,
+            locks: Vec<IndexTokenLock<T::BlockNumber, T::Balance>>,
+        ) {
+            let current_block = frame_system::Pallet::<T>::block_number();
+            let mut locked = T::Balance::zero();
+
+            let locks = locks
+                .into_iter()
+                .filter(|lock| {
+                    if current_block > lock.end_block {
+                        // lock period is over
+                        false
+                    } else {
+                        // track locked amount
+                        locked = locked.saturating_add(lock.locked);
+                        true
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            // set the lock, if it already exists, this will update it
+            T::IndexToken::set_lock(
+                T::IndexTokenLockIdentifier::get(),
+                user,
+                locked,
+                WithdrawReasons::all(),
+            );
+
+            IndexTokenLocks::<T>::insert(user, locks);
+            LockedIndexToken::<T>::insert(user, locked);
         }
     }
 

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -650,6 +650,16 @@ pub mod pallet {
             )?;
             Ok(().into())
         }
+
+        /// Updates the index token locks of the caller.
+        ///
+        /// This removes expired locks and updates the caller's index token balance accordingly.
+        #[pallet::weight(10_000)] // TODO: Set weights
+        pub fn unlock(origin: OriginFor<T>) -> DispatchResult {
+            let caller = ensure_signed(origin)?;
+            Self::do_update_index_token_locks(&caller);
+            Ok(())
+        }
     }
 
     impl<T: Config> Pallet<T> {

--- a/pallets/asset-index/src/mock.rs
+++ b/pallets/asset-index/src/mock.rs
@@ -9,6 +9,7 @@ use frame_support::{
     dispatch::DispatchResult,
     ord_parameter_types, parameter_types,
     sp_runtime::FixedPointNumber,
+    traits::LockIdentifier,
     traits::{GenesisBuild, StorageMapShim},
     PalletId,
 };
@@ -56,7 +57,6 @@ impl system::Config for Test {
     type BaseCallFilter = ();
     type BlockWeights = ();
     type BlockLength = ();
-    type DbWeight = ();
     type Origin = Origin;
     type Call = Call;
     type Index = u64;
@@ -68,6 +68,7 @@ impl system::Config for Test {
     type Header = Header;
     type Event = Event;
     type BlockHashCount = BlockHashCount;
+    type DbWeight = ();
     type Version = ();
     type PalletInfo = PalletInfo;
     type AccountData = ();
@@ -101,10 +102,10 @@ impl pallet_balances::Config for Test {
         AccountId,
         pallet_balances::AccountData<Balance>,
     >;
+    type WeightInfo = ();
     type MaxLocks = MaxLocks;
     type MaxReserves = ();
     type ReserveIdentifier = [u8; 8];
-    type WeightInfo = ();
 }
 
 parameter_type_with_key! {
@@ -120,8 +121,8 @@ impl orml_tokens::Config for Test {
     type CurrencyId = AssetId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type MaxLocks = MaxLocks;
     type OnDust = ();
+    type MaxLocks = MaxLocks;
 }
 
 parameter_types! {
@@ -130,6 +131,7 @@ parameter_types! {
     pub WithdrawalPeriod: <Test as system::Config>::BlockNumber = 10;
     pub DOTContributionLimit: Balance = 999;
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
+    pub IndexTokenLockIdentifier: LockIdentifier = *b"pintlock";
     pub StringLimit: u32 = 4;
     pub const PINTAssetId: AssetId = PINT_ASSET_ID;
 
@@ -139,21 +141,22 @@ parameter_types! {
 
 impl pallet_asset_index::Config for Test {
     type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
-    type Event = Event;
-    type AssetId = AssetId;
-    type SelfAssetId = PINTAssetId;
     type IndexToken = Balances;
     type Balance = Balance;
     type LockupPeriod = LockupPeriod;
+    type IndexTokenLockIdentifier = IndexTokenLockIdentifier;
     type MinimumRedemption = MinimumRedemption;
     type WithdrawalPeriod = WithdrawalPeriod;
     type DOTContributionLimit = DOTContributionLimit;
     type RemoteAssetManager = MockRemoteAssetManager;
+    type AssetId = AssetId;
+    type SelfAssetId = PINTAssetId;
     type Currency = Currency;
     type PriceFeed = MockPriceFeed;
-    type TreasuryPalletId = TreasuryPalletId;
-    type StringLimit = StringLimit;
     type BaseWithdrawalFee = BaseWithdrawalFee;
+    type TreasuryPalletId = TreasuryPalletId;
+    type Event = Event;
+    type StringLimit = StringLimit;
     type WeightInfo = ();
 }
 

--- a/pallets/asset-index/src/types.rs
+++ b/pallets/asset-index/src/types.rs
@@ -21,6 +21,16 @@ use xcm_executor::{
     Assets,
 };
 
+/// Abstraction over the lock of minted index token that are locked up
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct IndexTokenLockInfo<BlockNumber, Balance> {
+    /// Locked amount of index token.
+    pub locked: Balance,
+    /// The block when the locked index token can be unlocked.
+    pub end_block: BlockNumber,
+}
+
+
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 /// Defines the location of an asset
 /// Liquid implies it exists on a chain somewhere in the network and

--- a/pallets/asset-index/src/types.rs
+++ b/pallets/asset-index/src/types.rs
@@ -21,15 +21,15 @@ use xcm_executor::{
     Assets,
 };
 
-/// Abstraction over the lock of minted index token that are locked up
+/// Abstraction over the lock of minted index token that are locked up for
+/// `LockupPeriod`
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub struct IndexTokenLockInfo<BlockNumber, Balance> {
+pub struct IndexTokenLock<BlockNumber, Balance> {
     /// Locked amount of index token.
     pub locked: Balance,
     /// The block when the locked index token can be unlocked.
     pub end_block: BlockNumber,
 }
-
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 /// Defines the location of an asset

--- a/pallets/remote-asset-manager/src/mock.rs
+++ b/pallets/remote-asset-manager/src/mock.rs
@@ -7,7 +7,7 @@
 use cumulus_primitives_core::ParaId;
 use frame_support::{
     construct_runtime,
-    traits::All,
+    traits::{All, LockIdentifier},
     weights::{constants::WEIGHT_PER_SECOND, Weight},
 };
 use frame_support::{ord_parameter_types, parameter_types, traits::GenesisBuild, PalletId};
@@ -380,11 +380,12 @@ pub mod para {
     }
 
     parameter_types! {
-        pub LockupPeriod: <Runtime as system::Config>::BlockNumber = 10;
+        pub LockupPeriod: <Runtime as system::Config>::BlockNumber = 0;
         pub MinimumRedemption: u32 = 0;
         pub WithdrawalPeriod: <Runtime as system::Config>::BlockNumber = 10;
         pub DOTContributionLimit: Balance = 999;
         pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
+        pub IndexTokenLockIdentifier: LockIdentifier = *b"pintlock";
         pub ParaTreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
         pub StringLimit: u32 = 4;
 
@@ -405,6 +406,7 @@ pub mod para {
         type Event = Event;
         type AssetId = AssetId;
         type SelfAssetId = PINTAssetId;
+        type IndexTokenLockIdentifier = IndexTokenLockIdentifier;
         type IndexToken = Balances;
         type Balance = Balance;
         type LockupPeriod = LockupPeriod;

--- a/pallets/saft-registry/src/mock.rs
+++ b/pallets/saft-registry/src/mock.rs
@@ -5,7 +5,11 @@
 #![allow(clippy::from_over_into)]
 
 use crate as pallet_saft_registry;
-use frame_support::{ord_parameter_types, parameter_types, traits::StorageMapShim, PalletId};
+use frame_support::{
+    ord_parameter_types, parameter_types,
+    traits::{LockIdentifier, StorageMapShim},
+    PalletId,
+};
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
 use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
@@ -99,11 +103,12 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-    pub LockupPeriod: <Test as system::Config>::BlockNumber = 10;
+    pub LockupPeriod: <Test as system::Config>::BlockNumber = 0;
     pub MinimumRedemption: u32 = 2;
     pub WithdrawalPeriod: <Test as system::Config>::BlockNumber = 10;
     pub DOTContributionLimit: Balance = 999;
     pub TreasuryPalletId: PalletId = PalletId(*b"12345678");
+    pub IndexTokenLockIdentifier: LockIdentifier = *b"pintlock";
     pub StringLimit: u32 = 4;
     pub const PINTAssetId: AssetId = 99;
 
@@ -113,21 +118,22 @@ parameter_types! {
 
 impl pallet_asset_index::Config for Test {
     type AdminOrigin = frame_system::EnsureSignedBy<AdminAccountId, AccountId>;
-    type Event = Event;
-    type AssetId = AssetId;
-    type SelfAssetId = PINTAssetId;
     type IndexToken = Balances;
     type Balance = Balance;
     type LockupPeriod = LockupPeriod;
+    type IndexTokenLockIdentifier = IndexTokenLockIdentifier;
     type MinimumRedemption = MinimumRedemption;
     type WithdrawalPeriod = WithdrawalPeriod;
     type DOTContributionLimit = DOTContributionLimit;
     type RemoteAssetManager = MockRemoteAssetManager;
+    type AssetId = AssetId;
+    type SelfAssetId = PINTAssetId;
     type Currency = Currency;
     type PriceFeed = MockPriceFeed;
-    type TreasuryPalletId = TreasuryPalletId;
-    type StringLimit = StringLimit;
     type BaseWithdrawalFee = BaseWithdrawalFee;
+    type TreasuryPalletId = TreasuryPalletId;
+    type Event = Event;
+    type StringLimit = StringLimit;
     type WeightInfo = ();
 }
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- tracks minted index tokens (deposits) so that the `LockupPeriod` can be enforced
- add `unlock` extrinsic to manually unlock index tokens

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #212 