### PR TITLE
chore: rm unused adapter types

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -47,7 +47,6 @@ pub mod pallet {
     use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
 
     pub use crate::traits::AssetRecorder;
-    pub use crate::types::MultiAssetAdapter;
     use crate::types::{
         AssetAvailability, AssetMetadata, AssetWithdrawal, IndexTokenLock, PendingRedemption,
         RedemptionState,
@@ -901,7 +900,7 @@ pub mod pallet {
             // transfer the given units of asset from the caller into the treasury account
             T::Currency::transfer(asset_id, caller, &Self::treasury_account(), units)?;
             // mint PINT into caller's balance increasing the total issuance
-            T::IndexToken::deposit_creating(&caller, nav);
+            T::IndexToken::deposit_creating(caller, nav);
             Ok(())
         }
 
@@ -928,7 +927,7 @@ pub mod pallet {
             // mint SAFT into the treasury's account
             T::Currency::deposit(asset_id, &Self::treasury_account(), units)?;
             // mint PINT into caller's balance increasing the total issuance
-            T::IndexToken::deposit_creating(&caller, nav);
+            T::IndexToken::deposit_creating(caller, nav);
 
             Ok(())
         }

--- a/pallets/asset-index/src/mock.rs
+++ b/pallets/asset-index/src/mock.rs
@@ -230,9 +230,9 @@ impl Default for ExtBuilder {
     fn default() -> Self {
         Self {
             balances: vec![
-                (ADMIN_ACCOUNT_ID, ASSET_A_ID, 1000_000_000_000_000u128),
-                (ADMIN_ACCOUNT_ID, ASSET_B_ID, 1000_000_000_000_000u128),
-                (ADMIN_ACCOUNT_ID, SAFT_ASSET_ID, 1000_000_000_000_000u128),
+                (ADMIN_ACCOUNT_ID, ASSET_A_ID, 1_000_000_000_000_000_u128),
+                (ADMIN_ACCOUNT_ID, ASSET_B_ID, 1_000_000_000_000_000_u128),
+                (ADMIN_ACCOUNT_ID, SAFT_ASSET_ID, 1_000_000_000_000_000_u128),
             ],
         }
     }

--- a/pallets/asset-index/src/tests.rs
+++ b/pallets/asset-index/src/tests.rs
@@ -40,7 +40,7 @@ fn non_admin_cannot_call_get_asset() {
             ),
             BadOrigin
         );
-        assert_eq!(pallet::Assets::<Test>::contains_key(ASSET_A_ID), false)
+        assert!(!pallet::Assets::<Test>::contains_key(ASSET_A_ID))
     });
 }
 
@@ -522,8 +522,7 @@ fn can_withdraw() {
             pending
                 .assets
                 .iter()
-                .filter(|x| x.asset == ASSET_B_ID)
-                .next()
+                .find(|x| x.asset == ASSET_B_ID)
                 .expect("asset should be present"),
             &AssetWithdrawal {
                 asset: ASSET_B_ID,

--- a/pallets/asset-index/src/types.rs
+++ b/pallets/asset-index/src/types.rs
@@ -1,25 +1,8 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use codec::FullCodec;
 use frame_support::pallet_prelude::*;
-use frame_support::sp_runtime::traits::AtLeast32BitUnsigned;
-use frame_support::sp_runtime::SaturatedConversion;
-use frame_support::sp_std::{
-    self,
-    cmp::{Eq, PartialEq},
-    fmt::Debug,
-    marker::PhantomData,
-    prelude::*,
-    result,
-};
-use orml_traits::MultiCurrency;
-use primitives::traits::MultiAssetRegistry;
-use xcm::v0::{Error as XcmError, MultiAsset, MultiLocation, Result};
-use xcm_executor::{
-    traits::{Convert, MatchesFungible, TransactAsset},
-    Assets,
-};
+use xcm::opaque::v0::MultiLocation;
 
 /// Abstraction over the lock of minted index token that are locked up for
 /// `LockupPeriod`
@@ -90,106 +73,4 @@ pub struct AssetWithdrawal<AssetId, Balance> {
 pub struct PendingRedemption<AssetId, Balance, BlockNumber> {
     pub initiated: BlockNumber,
     pub assets: Vec<AssetWithdrawal<AssetId, Balance>>,
-}
-
-/// Asset transaction errors.
-enum Error {
-    /// Failed to match fungible.
-    FailedToMatchFungible,
-    /// `MultiLocation` to `AccountId` Conversion failed.
-    AccountIdConversionFailed,
-    /// `CurrencyId` conversion failed.
-    CurrencyIdConversionFailed,
-}
-
-impl From<Error> for XcmError {
-    fn from(e: Error) -> Self {
-        match e {
-            Error::FailedToMatchFungible => {
-                XcmError::FailedToTransactAsset("FailedToMatchFungible")
-            }
-            Error::AccountIdConversionFailed => {
-                XcmError::FailedToTransactAsset("AccountIdConversionFailed")
-            }
-            Error::CurrencyIdConversionFailed => {
-                XcmError::FailedToTransactAsset("CurrencyIdConversionFailed")
-            }
-        }
-    }
-}
-
-/// The `TransactAsset` implementation, to handle deposit/withdraw for a
-/// `MultiAsset`.
-#[allow(clippy::type_complexity)]
-pub struct MultiAssetAdapter<
-    Balance: AtLeast32BitUnsigned,
-    MultiAssets: MultiCurrency<AccountId, CurrencyId = AssetId, Balance = Balance>,
-    AssetRegistry: MultiAssetRegistry<AssetId>,
-    Matcher: MatchesFungible<Balance>,
-    AccountId: sp_std::fmt::Debug + sp_std::clone::Clone,
-    AccountIdConvert: Convert<MultiLocation, AccountId>,
-    AssetId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug,
-    AssetIdConvert: Convert<MultiAsset, AssetId>,
->(
-    PhantomData<(
-        Balance,
-        MultiAssets,
-        AssetRegistry,
-        Matcher,
-        AccountId,
-        AccountIdConvert,
-        AssetId,
-        AssetIdConvert,
-    )>,
-);
-impl<
-        Balance: AtLeast32BitUnsigned,
-        MultiAssets: MultiCurrency<AccountId, CurrencyId = AssetId, Balance = Balance>,
-        AssetRegistry: MultiAssetRegistry<AssetId>,
-        Matcher: MatchesFungible<Balance>,
-        AccountId: sp_std::fmt::Debug + sp_std::clone::Clone,
-        AccountIdConvert: Convert<MultiLocation, AccountId>,
-        AssetId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug,
-        AssetIdConvert: Convert<MultiAsset, AssetId>,
-    > TransactAsset
-    for MultiAssetAdapter<
-        Balance,
-        MultiAssets,
-        AssetRegistry,
-        Matcher,
-        AccountId,
-        AccountIdConvert,
-        AssetId,
-        AssetIdConvert,
-    >
-{
-    fn deposit_asset(asset: &MultiAsset, location: &MultiLocation) -> Result {
-        match (
-            AccountIdConvert::convert(location.clone()),
-            AssetIdConvert::convert(asset.clone()),
-            Matcher::matches_fungible(asset),
-        ) {
-            // known asset
-            (Ok(who), Ok(asset_id), Some(amount)) => MultiAssets::deposit(asset_id, &who, amount)
-                .map_err(|e| XcmError::FailedToTransactAsset(e.into())),
-            // unknown asset
-            _ => Err(XcmError::FailedToTransactAsset("Unknown Asset")),
-        }
-    }
-
-    fn withdraw_asset(
-        asset: &MultiAsset,
-        location: &MultiLocation,
-    ) -> result::Result<Assets, XcmError> {
-        let who = AccountIdConvert::convert(location.clone())
-            .map_err(|_| XcmError::from(Error::AccountIdConversionFailed))?;
-        let asset_id = AssetIdConvert::convert(asset.clone())
-            .map_err(|_| XcmError::from(Error::CurrencyIdConversionFailed))?;
-        let amount: Balance = Matcher::matches_fungible(&asset)
-            .ok_or_else(|| XcmError::from(Error::FailedToMatchFungible))?
-            .saturated_into();
-        MultiAssets::withdraw(asset_id, &who, amount)
-            .map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
-        Ok(asset.clone().into())
-    }
 }

--- a/pallets/asset-index/src/types.rs
+++ b/pallets/asset-index/src/types.rs
@@ -1,7 +1,8 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
-use frame_support::pallet_prelude::*;
+use codec::{Decode, Encode};
+use frame_support::{sp_runtime::RuntimeDebug, sp_std::vec::Vec};
 use xcm::opaque::v0::MultiLocation;
 
 /// Abstraction over the lock of minted index token that are locked up for


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- drop unused adapter types that was replaced with `orml_currency` and `orml_xtokens`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->


## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-