### PR TITLE
feat: abstract all NAV related calculations over NavProvider trait

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -1045,7 +1045,7 @@ pub mod pallet {
                         if T::Currency::transfer(
                             asset.asset,
                             &Self::treasury_account(),
-                            &caller,
+                            caller,
                             asset.units,
                         )
                         .is_ok()
@@ -1061,7 +1061,7 @@ pub mod pallet {
                         if T::Currency::transfer(
                             asset.asset,
                             &Self::treasury_account(),
-                            &caller,
+                            caller,
                             asset.units,
                         )
                         .is_ok()

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -53,6 +53,7 @@ pub mod pallet {
         AssetAvailability, AssetMetadata, AssetRedemption, AssetVolume, AssetWithdrawal,
         AssetsDistribution, AssetsVolume, IndexTokenLock, PendingRedemption, RedemptionState,
     };
+    use frame_support::sp_runtime::traits::CheckedMul;
     use primitives::traits::{NavProvider, UnbondingOutcome};
     use primitives::{
         fee::{BaseFee, FeeRate},
@@ -771,20 +772,6 @@ pub mod pallet {
                 .ok_or(Error::<T>::NAVOverflow)?)
         }
 
-        /// Calculates the combined net worth of all the given assets
-        fn calculate_combined_net_worth(
-            iter: impl Iterator<Item = T::AssetId>,
-        ) -> Result<T::Balance, DispatchError> {
-            iter.into_iter().try_fold(
-                T::Balance::zero(),
-                |worth, asset| -> Result<_, DispatchError> {
-                    worth
-                        .checked_add(&Self::asset_net_worth(asset)?)
-                        .ok_or_else(|| Error::<T>::NAVOverflow.into())
-                },
-            )
-        }
-
         /// Calculates the volume of the given units with the provided price
         fn calculate_volume(
             units: T::Balance,
@@ -1226,7 +1213,28 @@ pub mod pallet {
             asset: T::AssetId,
             units: T::Balance,
         ) -> Result<T::Balance, DispatchError> {
-            todo!()
+            let nav = Self::total_nav()?;
+            if nav.is_zero() {
+                return Ok(T::Balance::zero());
+            }
+            let assets = Self::calculate_asset_net_worth(asset, units)?;
+            Ok(assets.checked_div(&nav).ok_or(Error::<T>::NAVOverflow)?)
+        }
+
+        fn asset_equivalent(
+            index_tokens: T::Balance,
+            asset: T::AssetId,
+        ) -> Result<T::Balance, DispatchError> {
+            let nav = Self::total_nav()?;
+            let vol = index_tokens
+                .checked_mul(&nav)
+                .ok_or(Error::<T>::NAVOverflow)?;
+            let price = T::PriceFeed::get_price(asset)?;
+            price
+                .reciprocal_volume(vol.into())
+                .ok_or(Error::<T>::NAVOverflow)?
+                .try_into()
+                .map_err(|_| Error::<T>::AssetUnitsOverflow.into())
         }
 
         fn calculate_asset_net_worth(
@@ -1250,24 +1258,11 @@ pub mod pallet {
         }
 
         fn calculate_saft_net_worth(
-            asset: T::AssetId,
-            units: T::Balance,
+            _asset: T::AssetId,
+            _units: T::Balance,
         ) -> Result<T::Balance, DispatchError> {
+            // needs https://github.com/ChainSafe/PINT/issues/250
             todo!("access the SAFT records")
-        }
-
-        fn total_asset_net_worth() -> Result<T::Balance, DispatchError> {
-            Assets::<T>::iter().try_fold(
-                T::Balance::zero(),
-                |worth, (asset, availability)| -> Result<_, DispatchError> {
-                    if availability.is_liquid() {
-                        worth.checked_add(&Self::liquid_net_worth(asset)?)
-                    } else {
-                        worth.checked_add(&Self::saft_net_worth(asset)?)
-                    }
-                    .ok_or_else(|| Error::<T>::NAVOverflow.into())
-                },
-            )
         }
 
         fn total_liquid_net_worth() -> Result<T::Balance, DispatchError> {
@@ -1292,16 +1287,51 @@ pub mod pallet {
             )
         }
 
+        fn total_net_worth() -> Result<T::Balance, DispatchError> {
+            Assets::<T>::iter().try_fold(
+                T::Balance::zero(),
+                |worth, (asset, availability)| -> Result<_, DispatchError> {
+                    if availability.is_liquid() {
+                        worth.checked_add(&Self::liquid_net_worth(asset)?)
+                    } else {
+                        worth.checked_add(&Self::saft_net_worth(asset)?)
+                    }
+                    .ok_or_else(|| Error::<T>::NAVOverflow.into())
+                },
+            )
+        }
+
         fn total_nav() -> Result<T::Balance, DispatchError> {
-            todo!()
+            let total_issuance = T::IndexToken::total_issuance();
+            if total_issuance.is_zero() {
+                return Ok(T::Balance::zero());
+            }
+            let assets = Self::total_net_worth()?;
+            assets
+                .checked_div(&total_issuance)
+                .ok_or_else(|| Error::<T>::NAVOverflow.into())
         }
 
         fn liquid_nav() -> Result<T::Balance, DispatchError> {
-            todo!()
+            let total_issuance = T::IndexToken::total_issuance();
+            if total_issuance.is_zero() {
+                return Ok(T::Balance::zero());
+            }
+            let assets = Self::total_liquid_net_worth()?;
+            assets
+                .checked_div(&total_issuance)
+                .ok_or_else(|| Error::<T>::NAVOverflow.into())
         }
 
         fn saft_nav() -> Result<T::Balance, DispatchError> {
-            todo!()
+            let total_issuance = T::IndexToken::total_issuance();
+            if total_issuance.is_zero() {
+                return Ok(T::Balance::zero());
+            }
+            let assets = Self::total_saft_net_worth()?;
+            assets
+                .checked_div(&total_issuance)
+                .ok_or_else(|| Error::<T>::NAVOverflow.into())
         }
 
         fn index_token_issuance() -> T::Balance {

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -91,10 +91,30 @@ pub trait NavProvider<AssetId: Clone, Balance> {
     fn total_asset_net_worth() -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of all liquid assets combined.
-    fn liquid_net_worth() -> Result<Balance, DispatchError>;
+    fn total_liquid_net_worth() -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of all SAFT combined.
-    fn saft_net_worth() -> Result<Balance, DispatchError>;
+    fn total_saft_net_worth() -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of the given liquid asset.
+    ///
+    /// In contrast to `asset_net_worth`, here it is not checked whether the specified asset is liquid.
+    fn liquid_net_worth(asset: AssetId) -> Result<Balance, DispatchError> {
+        Self::calculate_liquid_asset_net_worth(
+            asset.clone(),
+            Self::asset_balance(asset)
+        )
+    }
+
+    /// Calculates the net worth of the given SAFT.
+    ///
+    /// In contrast to `asset_net_worth`, here it is not checked whether the specified asset is a SAFT.
+    fn saft_net_worth(asset: AssetId) -> Result<Balance, DispatchError> {
+        Self::calculate_saft_net_worth(
+            asset.clone(),
+            Self::asset_balance(asset)
+        )
+    }
 
     /// Calculates the total NAV of the index token, consiting of liquid assets and SAFT
     ///

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -1,9 +1,15 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
+//! This contains shared traits that are used in multiple pallets to prevent
+//! circular dependencies
+
 use codec::{Decode, Encode};
 use frame_support::{
-    dispatch::DispatchError, sp_runtime::DispatchResult, sp_std::boxed::Box, RuntimeDebug,
+    dispatch::DispatchError,
+    sp_runtime::DispatchResult,
+    sp_std::{boxed::Box, result::Result},
+    RuntimeDebug,
 };
 use xcm::v0::{MultiLocation, Outcome};
 
@@ -42,6 +48,78 @@ pub trait RemoteAssetManager<AccountId, AssetId, Balance> {
 
     /// Dispatch XCM to unbond assets
     fn unbond(asset: AssetId, amount: Balance) -> UnbondingOutcome;
+}
+
+/// Abstracts net asset value (NAV) related calculations
+pub trait NavProvider<AssetId: Clone, Balance> {
+    /// Calculates the amount of index tokens that the given amount of the asset
+    /// are worth.
+    ///
+    /// This is achieved by dividing the worth of the given units by the NAV.
+    /// The worth, or volume, is determined by `vol_asset = units * Price_asset`
+    /// (`asset_net_worth`), and since the `NAV` represents the per token value,
+    /// the equivalent number of index token is `vol_asset / NAV`.
+    fn index_token_equivalent(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of the given units of the given asset.
+    /// .
+    /// If the asset is liquid then the net worth of an asset is determined by multiplying the share price of the asset by the given amount.: `units * Price_asset`.
+    ///
+    /// If the asset is liquid then the net worth is determined by the net worth of the associated `SAFTRecords`.
+    fn calculate_asset_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of the given units of the given *liquid* asset.
+    ///
+    /// In contrast to `calculate_asset_net_worth`, here it is not checked whether the specified asset is liquid, but it is expected that this is the case and it attempts to determine the net worth using the asset's price feed.
+    fn calculate_liquid_asset_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of the given units of the given SAFT.
+    ///
+    /// In contrast to `calculate_asset_net_worth`, here it is not checked whether the specified asset is SAFT. The net worth is then determined by the tracked `SAFTRecords`
+    fn calculate_saft_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of the given asset contributed to the index.
+    ///
+    /// The net worth of an asset is determined by multiplying the share price
+    /// of the asset by the amount deposited in the index.: `Price_asset * Index
+    /// Deposit`
+    fn asset_net_worth(asset: AssetId) -> Result<Balance, DispatchError> {
+        Self::calculate_asset_net_worth(asset.clone(), Self::asset_balance(asset))
+    }
+
+    /// Calculates the net worth of all assets combined.
+    fn total_asset_net_worth() -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of all liquid assets combined.
+    fn liquid_net_worth() -> Result<Balance, DispatchError>;
+
+    /// Calculates the net worth of all SAFT combined.
+    fn saft_net_worth() -> Result<Balance, DispatchError>;
+
+    /// Calculates the total NAV of the index token, consiting of liquid assets and SAFT
+    ///
+    /// The NAV represents the fund's per token value.
+    /// The the NAV is calculated by dividing the total value of all the
+    /// contributed assets by the total supply of index token:
+    /// `NAV = (Asset_0 + Asset_1+ ... + Asset_n) / Total Supply`. where
+    /// `Asset_n` is the net worth of all shares of the specific asset that were
+    /// contributed to the index. And the sum of all of them is the `total_asset_net_worth`
+    ///
+    /// To determine the net value of the assets, and then ultimately the `NAV`,
+    /// the prices of the assets are required.
+    fn total_nav() -> Result<Balance, DispatchError>;
+
+    /// Calculates the NAV of the index token solely based on the liquid assets
+    fn liquid_nav() -> Result<Balance, DispatchError>;
+
+    /// Calculates the NAV of the index token solely based on the SAFT
+    fn saft_nav() -> Result<Balance, DispatchError>;
+
+    /// The total supply of index tokens currently in circulation.
+    fn index_token_issuance() -> Balance;
+
+    /// The amount of the specified asset currently held in the index.
+    fn asset_balance(asset: AssetId) -> Balance;
 }
 
 /// Outcome of an XCM unbonding api call

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -50,9 +50,9 @@ pub trait RemoteAssetManager<AccountId, AssetId, Balance> {
     fn unbond(asset: AssetId, amount: Balance) -> UnbondingOutcome;
 }
 
-/// Abstracts net asset value (NAV) related calculations
+/// Abstracts net asset value (`NAV`) related calculations
 pub trait NavProvider<AssetId: Clone, Balance> {
-    /// Calculates the amount of index tokens that the given amount of the asset
+    /// Calculates the amount of index tokens that the given units of the asset
     /// are worth.
     ///
     /// This is achieved by dividing the worth of the given units by the NAV.
@@ -61,21 +61,40 @@ pub trait NavProvider<AssetId: Clone, Balance> {
     /// the equivalent number of index token is `vol_asset / NAV`.
     fn index_token_equivalent(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
 
+    /// Calculates the units of the given asset that the given number of
+    /// index_tokens are worth.
+    ///
+    /// This is calculated by determine the net worth of the given
+    /// `index_tokens` and dividing it by the price of the `asset`.
+    /// (`NAV * index_tokens) / Price_asset`
+    fn asset_equivalent(index_tokens: Balance, asset: AssetId) -> Result<Balance, DispatchError>;
+
     /// Calculates the net worth of the given units of the given asset.
     /// .
-    /// If the asset is liquid then the net worth of an asset is determined by multiplying the share price of the asset by the given amount.: `units * Price_asset`.
+    /// If the asset is liquid then the net worth of an asset is determined by
+    /// multiplying the share price of the asset by the given amount.: `units *
+    /// Price_asset`.
     ///
-    /// If the asset is liquid then the net worth is determined by the net worth of the associated `SAFTRecords`.
+    /// If the asset is liquid then the net worth is determined by the net worth
+    /// of the associated `SAFTRecords`.
     fn calculate_asset_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of the given units of the given *liquid* asset.
     ///
-    /// In contrast to `calculate_asset_net_worth`, here it is not checked whether the specified asset is liquid, but it is expected that this is the case and it attempts to determine the net worth using the asset's price feed.
-    fn calculate_liquid_asset_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
+    /// In contrast to `calculate_asset_net_worth`, here it is not checked
+    /// whether the specified asset is liquid, but it is expected that this is
+    /// the case and it attempts to determine the net worth using the asset's
+    /// price feed.
+    fn calculate_liquid_asset_net_worth(
+        asset: AssetId,
+        units: Balance,
+    ) -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of the given units of the given SAFT.
     ///
-    /// In contrast to `calculate_asset_net_worth`, here it is not checked whether the specified asset is SAFT. The net worth is then determined by the tracked `SAFTRecords`
+    /// In contrast to `calculate_asset_net_worth`, here it is not checked
+    /// whether the specified asset is SAFT. The net worth is then determined by
+    /// the tracked `SAFTRecords`
     fn calculate_saft_net_worth(asset: AssetId, units: Balance) -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of the given asset contributed to the index.
@@ -87,58 +106,72 @@ pub trait NavProvider<AssetId: Clone, Balance> {
         Self::calculate_asset_net_worth(asset.clone(), Self::asset_balance(asset))
     }
 
-    /// Calculates the net worth of all assets combined.
-    fn total_asset_net_worth() -> Result<Balance, DispatchError>;
-
     /// Calculates the net worth of all liquid assets combined.
     fn total_liquid_net_worth() -> Result<Balance, DispatchError>;
 
     /// Calculates the net worth of all SAFT combined.
     fn total_saft_net_worth() -> Result<Balance, DispatchError>;
 
+    /// Calculates the net worth of all the index tokens which is equal to the
+    /// sum of all assets.
+    ///
+    /// Since the `NAV` represents the per index token value, net worth of all
+    /// index tokens is the product of the `NAV` and the total supply of index
+    /// tokens: `NAV * index_token_issuance`.
+    /// Or Simplified:
+    /// `total_liquid_net_worth + total_saft_net_worth`.
+    fn total_net_worth() -> Result<Balance, DispatchError>;
+
     /// Calculates the net worth of the given liquid asset.
     ///
-    /// In contrast to `asset_net_worth`, here it is not checked whether the specified asset is liquid.
+    /// In contrast to `asset_net_worth`, here it is not checked whether the
+    /// specified asset is liquid.
     fn liquid_net_worth(asset: AssetId) -> Result<Balance, DispatchError> {
-        Self::calculate_liquid_asset_net_worth(
-            asset.clone(),
-            Self::asset_balance(asset)
-        )
+        Self::calculate_liquid_asset_net_worth(asset.clone(), Self::asset_balance(asset))
     }
 
     /// Calculates the net worth of the given SAFT.
     ///
-    /// In contrast to `asset_net_worth`, here it is not checked whether the specified asset is a SAFT.
+    /// In contrast to `asset_net_worth`, here it is not checked whether the
+    /// specified asset is a SAFT.
     fn saft_net_worth(asset: AssetId) -> Result<Balance, DispatchError> {
-        Self::calculate_saft_net_worth(
-            asset.clone(),
-            Self::asset_balance(asset)
-        )
+        Self::calculate_saft_net_worth(asset.clone(), Self::asset_balance(asset))
     }
 
-    /// Calculates the total NAV of the index token, consiting of liquid assets and SAFT
+    /// Calculates the total NAV of the index token, consisting of liquid assets
+    /// and SAFT
     ///
     /// The NAV represents the fund's per token value.
     /// The the NAV is calculated by dividing the total value of all the
     /// contributed assets by the total supply of index token:
     /// `NAV = (Asset_0 + Asset_1+ ... + Asset_n) / Total Supply`. where
     /// `Asset_n` is the net worth of all shares of the specific asset that were
-    /// contributed to the index. And the sum of all of them is the `total_asset_net_worth`
+    /// contributed to the index. And the sum of all of them is the
+    /// `total_asset_net_worth`
     ///
-    /// To determine the net value of the assets, and then ultimately the `NAV`,
-    /// the prices of the assets are required.
+    /// This can be simplified to
+    /// `NAV = (Liquid_net_worth + SAFT_net_worth) / Total Supply`,
+    /// which is also `NAV = NAV_liquids + NAV_saft`.
     fn total_nav() -> Result<Balance, DispatchError>;
 
-    /// Calculates the NAV of the index token solely based on the liquid assets
+    /// Calculates the NAV of the index token solely for the liquid assets
+    ///
+    /// Following the `total_nav` calculation, the `NAV_liquids` is determined
+    /// by `NAV_liquids = NAV - (SAFT_net_worth / Total Supply)`
+    /// Or simplified
+    /// `NAV - NAV_saft`, which is  `Liquid_net_worth / Total Supply`
     fn liquid_nav() -> Result<Balance, DispatchError>;
 
-    /// Calculates the NAV of the index token solely based on the SAFT
+    /// Calculates the NAV of the index token solely for the SAFT
+    ///
+    /// Following `liquid_nav` calculation, this is determined by:
+    /// `SAFT_net_worth / Total Supply`
     fn saft_nav() -> Result<Balance, DispatchError>;
 
     /// The total supply of index tokens currently in circulation.
     fn index_token_issuance() -> Balance;
 
-    /// The amount of the specified asset currently held in the index.
+    /// The amount of the given asset currently held in the index.
     fn asset_balance(asset: AssetId) -> Balance;
 }
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Introduce `NavProvider` that abstracts all NAV calculations and explains all terminology and formula
- Fixes some soundness issues when performing NAV calculations

The `NavProvider` comes with dedicated functions for `SAFT`, `liquid` and `index token`, perhaps it makes sense to further split that?

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->
- Closes #248 
- Follow up #250