### PR TITLE
feat: handle xcm staking calls on a per block basis

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -456,6 +456,9 @@ pub mod pallet {
 			// mint index token in caller's account
 			Self::do_mint_index_token(&caller, index_tokens);
 
+			// tell the remote asset manager that assets are available to bond
+			T::RemoteAssetManager::deposit(asset_id, units);
+
 			Self::deposit_event(Event::Deposited(asset_id, units, caller, index_tokens));
 			Ok(())
 		}
@@ -515,8 +518,8 @@ pub mod pallet {
 
 			// start the redemption process for each withdrawal
 			for (asset, units) in asset_amounts {
-				// start the unbonding routine
-				T::RemoteAssetManager::unbond(asset, units);
+				// announce the unbonding routine
+				T::RemoteAssetManager::announce_withdrawal(asset, units);
 				// reserve the funds in the treasury's account until the redemption period is
 				// over after which they can be transferred to the user account
 				// NOTE: this should always succeed due to the way the asset distribution is

--- a/pallets/asset-index/src/mock.rs
+++ b/pallets/asset-index/src/mock.rs
@@ -6,7 +6,6 @@
 
 use crate as pallet_asset_index;
 use frame_support::{
-	dispatch::DispatchResult,
 	ord_parameter_types, parameter_types,
 	traits::{GenesisBuild, LockIdentifier, StorageMapShim},
 	PalletId,
@@ -14,11 +13,7 @@ use frame_support::{
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
 use pallet_price_feed::PriceFeed;
-use primitives::{
-	fee::FeeRate,
-	traits::{RemoteAssetManager, UnbondingOutcome},
-	AssetPricePair, Price,
-};
+use primitives::{fee::FeeRate, traits::RemoteAssetManager, AssetPricePair, Price};
 use sp_core::H256;
 use sp_std::cell::RefCell;
 use std::collections::HashMap;
@@ -185,13 +180,9 @@ impl<AccountId, AssetId, Balance> RemoteAssetManager<AccountId, AssetId, Balance
 		Ok(Outcome::Complete(0))
 	}
 
-	fn bond(_: AssetId, _: Balance) -> DispatchResult {
-		Ok(())
-	}
+	fn deposit(_: AssetId, _: Balance) {}
 
-	fn unbond(_: AssetId, _: Balance) -> UnbondingOutcome {
-		UnbondingOutcome::NotSupported
-	}
+	fn announce_withdrawal(_: AssetId, _: Balance) {}
 }
 
 pub const PINT_ASSET_ID: AssetId = 0u32;

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -356,7 +356,19 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+
+		/// Check for staking calls we need to get in this block
+		///
+		/// This will compare the pending withdrawals against the free balance of each asset and determine whether an XCM unbond, bond_extra or withdrawal is in order
+		///
+		fn on_initialize(now: T::BlockNumber) -> Weight {
+
+
+			0
+		}
+
+	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -978,7 +978,7 @@ pub mod pallet {
 		}
 
 		fn minimum_free_stash_balance(asset: &T::AssetId) -> T::Balance {
-			T::StakingThreshold::minimum_resereve_balance(*asset)
+			T::StakingThreshold::minimum_reserve_balance(*asset)
 		}
 	}
 

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -386,18 +386,25 @@ pub mod pallet {
 		/// amount of on asset a LP receives upon redeeming their PINT directly correlates with the
 		/// value of each asset.
 		///
+		/// If an asset's chain supports staking (it was previously bonded with
+		/// `pallet_staking::bond`) then we need to check what action is appropriate in this for
+		/// this asset's staking pallet. Following states exists:
+		///    - `Idle`: nothing to bond_extra, unbond or withdraw
+		///    - `BondExtra`: new deposits were added to the PINT's parachain balance sheet and can
+		///      now be bonded. This will also check if currently unbonded funds can be rebonded
+		///      again instead.
+		///    - `Unbond`: pending withdrawals reached a threshold were we need to unbund staked
+		///      funds.
+		///    - `Withdraw`: The bonding duration of an unlocking chunk is over and the funds are now
+		///      safe to withdraw via `withdraw_unbonded`
+		///
 		/// The maximum number of separate xcm calls we send here is limited to the number of liquid
 		/// assets with staking support.
 		fn on_finalize(now: T::BlockNumber) {
 			// check all assets with enabled cross chain staking support
-			for (asset, config) in  PalletStakingConfig::<T>::iter() {
+			for (asset, config) in PalletStakingConfig::<T>::iter() {
 				// consider only location which are already bonded
-				if let Some(mut ledger) = PalletStakingLedger::<T>::get(&asset) {
-						// determine xcm action
-
-				}
-
-
+				if let Some(mut ledger) = PalletStakingLedger::<T>::get(&asset) {}
 				// update ledger
 			}
 
@@ -406,9 +413,6 @@ pub mod pallet {
 			// check if we need to withdraw
 
 			// check if we need to unbond
-
-
-
 		}
 	}
 

--- a/pallets/remote-asset-manager/src/mock.rs
+++ b/pallets/remote-asset-manager/src/mock.rs
@@ -382,8 +382,14 @@ pub mod para {
 	}
 
 	parameter_type_with_key! {
-		pub MinimumRemoteStashBalance: |_asset_id: AssetId| -> Balance {
+		pub MinimumReserve: |_asset_id: AssetId| -> Balance {
 			ExistentialDeposit::get()
+		};
+	}
+
+	parameter_type_with_key! {
+		pub MinimumBondExtra: |_asset_id: AssetId| -> Balance {
+			1_000
 		};
 	}
 
@@ -482,7 +488,7 @@ pub mod para {
 		type SelfLocation = SelfLocation;
 		type SelfParaId = parachain_info::Pallet<Runtime>;
 		type RelayChainAssetId = RelayChainAssetId;
-		type MinimumRemoteStashBalance = MinimumRemoteStashBalance;
+		type StakingThreshold = (MinimumReserve, MinimumBondExtra);
 		type Assets = Currency;
 		type XcmExecutor = XcmExecutor<XcmConfig>;
 		type XcmAssetTransfer = XTokens;

--- a/pallets/remote-asset-manager/src/tests.rs
+++ b/pallets/remote-asset-manager/src/tests.rs
@@ -38,6 +38,7 @@ fn print_events<T: frame_system::Config>(context: &str) {
 	});
 }
 
+#[allow(unused)]
 fn run_to_block<Runtime>(n: u64)
 where
 	Runtime: pallet_remote_asset_manager::Config<BlockNumber = BlockNumber>,

--- a/pallets/remote-asset-manager/src/tests.rs
+++ b/pallets/remote-asset-manager/src/tests.rs
@@ -26,6 +26,7 @@ use crate::{
 	pallet as pallet_remote_asset_manager,
 	types::StatemintConfig,
 };
+use frame_support::traits::Hooks;
 use pallet_price_feed::PriceFeed;
 use primitives::traits::NavProvider;
 
@@ -35,6 +36,19 @@ fn print_events<T: frame_system::Config>(context: &str) {
 	frame_system::Pallet::<T>::events().iter().for_each(|r| {
 		println!("{:?}", r.event);
 	});
+}
+
+fn run_to_block<Runtime>(n: u64)
+where
+	Runtime: pallet_remote_asset_manager::Config<BlockNumber = BlockNumber>,
+{
+	while frame_system::Pallet::<Runtime>::block_number() < n {
+		pallet_remote_asset_manager::Pallet::<Runtime>::on_finalize(frame_system::Pallet::<Runtime>::block_number());
+		frame_system::Pallet::<Runtime>::on_finalize(frame_system::Pallet::<Runtime>::block_number());
+		frame_system::Pallet::<Runtime>::set_block_number(frame_system::Pallet::<Runtime>::block_number() + 1);
+		frame_system::Pallet::<Runtime>::on_initialize(frame_system::Pallet::<Runtime>::block_number());
+		pallet_remote_asset_manager::Pallet::<Runtime>::on_initialize(frame_system::Pallet::<Runtime>::block_number());
+	}
 }
 
 /// registers the relay chain as liquid asset

--- a/pallets/remote-asset-manager/src/traits.rs
+++ b/pallets/remote-asset-manager/src/traits.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 use frame_support::dispatch::DispatchResult;
+use orml_traits::GetByKey;
 
 /// The trait that provides balances related info about the parachain's various
 /// sovereign accounts.
@@ -36,4 +37,35 @@ pub trait BalanceMeter<Balance, AssetId> {
 	/// Returns the configured minimum stash balance below which the parachain's
 	/// sovereign account balance must not fall.
 	fn minimum_free_stash_balance(asset: &AssetId) -> Balance;
+}
+
+/// A type to abstract several staking related thresholds
+pub trait StakingThresholds<AssetId, Balance> {
+	/// The minimum amount that should be held in stash (must remain
+	/// unbonded).
+	/// Withdrawals are only authorized if the updated stash balance does
+	/// exceeds this.
+	///
+	/// This must be at least the `ExistentialDeposit` as configured on the
+	/// asset's native chain (e.g. DOT/Polkadot)
+	fn minimum_resereve_balance(asset: AssetId) -> Balance;
+
+	/// The minimum required amount to justify an additional `bond_extra` XCM call to stake
+	/// additional funds.
+	fn minimum_bond_extra(asset: AssetId) -> Balance;
+}
+
+// Convenience impl for orml `parameter_type_with_key!` impls
+impl<AssetId, Balance, ReserveMinimum, BondExtra> StakingThresholds<AssetId, Balance> for (ReserveMinimum, BondExtra)
+where
+	ReserveMinimum: GetByKey<AssetId, Balance>,
+	BondExtra: GetByKey<AssetId, Balance>,
+{
+	fn minimum_resereve_balance(asset: AssetId) -> Balance {
+		ReserveMinimum::get(&asset)
+	}
+
+	fn minimum_bond_extra(asset: AssetId) -> Balance {
+		BondExtra::get(&asset)
+	}
 }

--- a/pallets/remote-asset-manager/src/traits.rs
+++ b/pallets/remote-asset-manager/src/traits.rs
@@ -48,7 +48,7 @@ pub trait StakingThresholds<AssetId, Balance> {
 	///
 	/// This must be at least the `ExistentialDeposit` as configured on the
 	/// asset's native chain (e.g. DOT/Polkadot)
-	fn minimum_resereve_balance(asset: AssetId) -> Balance;
+	fn minimum_reserve_balance(asset: AssetId) -> Balance;
 
 	/// The minimum required amount to justify an additional `bond_extra` XCM call to stake
 	/// additional funds.
@@ -61,7 +61,7 @@ where
 	ReserveMinimum: GetByKey<AssetId, Balance>,
 	BondExtra: GetByKey<AssetId, Balance>,
 {
-	fn minimum_resereve_balance(asset: AssetId) -> Balance {
+	fn minimum_reserve_balance(asset: AssetId) -> Balance {
 		ReserveMinimum::get(&asset)
 	}
 

--- a/pallets/remote-asset-manager/src/types.rs
+++ b/pallets/remote-asset-manager/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 use codec::{Decode, Encode};
-use frame_support::RuntimeDebug;
+use frame_support::{sp_runtime::traits::AtLeast32BitUnsigned, RuntimeDebug};
 use xcm::v0::{Junction, MultiLocation};
 use xcm_calls::assets::AssetsConfig;
 
@@ -15,6 +15,27 @@ pub struct XcmStakingMessageCount {
 	pub unbond: u32,
 	/// Total number of all `pallet_staking::Pallet::withdraw_unbonded` calls transacted
 	pub withdraw_unbonded: u32,
+}
+
+/// Represents the different balances of an asset
+#[derive(Default, Encode, Decode, Clone, PartialEq, RuntimeDebug)]
+pub struct AssetLedger<Balance> {
+	/// The real deposits contributed to the index
+	pub deposited: Balance,
+	/// the amount of the asset about to be withdrawn
+	pub pending_redemption: Balance,
+}
+
+impl<Balance> AssetLedger<Balance>
+where
+	Balance: AtLeast32BitUnsigned + Copy,
+{
+	/// Cancel each balance out, after which at least 1 balance is zero.
+	pub fn consolidate(&mut self) {
+		let deposited = self.deposited;
+		self.deposited = self.deposited.saturating_sub(self.pending_redemption);
+		self.pending_redemption = self.pending_redemption.saturating_sub(deposited);
+	}
 }
 
 /// Represents the config for the statemint parachain

--- a/pallets/remote-asset-manager/src/types.rs
+++ b/pallets/remote-asset-manager/src/types.rs
@@ -6,6 +6,17 @@ use frame_support::RuntimeDebug;
 use xcm::v0::{Junction, MultiLocation};
 use xcm_calls::assets::AssetsConfig;
 
+/// Represents all XCM calls of the `pallet_staking` pallet transacted on a parachain
+#[derive(Default, Encode, Decode, Clone, PartialEq, RuntimeDebug)]
+pub struct XcmStakingMessageCount {
+	/// Total number of all `pallet_staking::Pallet::bond_extra` calls transacted
+	pub bond_extra: u32,
+	/// Total number of all `pallet_staking::Pallet::unbond` calls transacted
+	pub unbond: u32,
+	/// Total number of all `pallet_staking::Pallet::withdraw_unbonded` calls transacted
+	pub withdraw_unbonded: u32,
+}
+
 /// Represents the config for the statemint parachain
 #[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]

--- a/pallets/saft-registry/src/mock.rs
+++ b/pallets/saft-registry/src/mock.rs
@@ -13,8 +13,7 @@ use frame_support::{
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
 use pallet_price_feed::{AssetPricePair, Price, PriceFeed};
-use primitives::traits::{RemoteAssetManager, UnbondingOutcome};
-use sp_runtime::DispatchResult;
+use primitives::traits::RemoteAssetManager;
 
 use sp_core::H256;
 use sp_runtime::{
@@ -144,13 +143,9 @@ impl<AccountId, AssetId, Balance> RemoteAssetManager<AccountId, AssetId, Balance
 		Ok(Outcome::Complete(0))
 	}
 
-	fn bond(_: AssetId, _: Balance) -> DispatchResult {
-		Ok(())
-	}
+	fn deposit(_: AssetId, _: Balance) {}
 
-	fn unbond(_: AssetId, _: Balance) -> UnbondingOutcome {
-		UnbondingOutcome::NotSupported
-	}
+	fn announce_withdrawal(_: AssetId, _: Balance) {}
 }
 
 pub struct MockPriceFeed;

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -146,8 +146,16 @@ parameter_type_with_key! {
 
 // The minimum amount of assets that should remain unbonded.
 parameter_type_with_key! {
-	pub MinimumRemoteStashBalance: |_asset_id: AssetId| -> Balance {
+	pub MinimumRemoteReserveBalance: |_asset_id: AssetId| -> Balance {
 		// Same as relaychain existential deposit
 		ExistentialDeposit::get()
+	};
+}
+
+// The minimum amount of asset required for an additional bond_extr
+parameter_type_with_key! {
+	pub MinimumBondExtra: |_asset_id: AssetId| -> Balance {
+		// set this to max for now, effectively preventing automated bond_extra
+		Balance::MAX
 	};
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -620,7 +620,7 @@ impl pallet_remote_asset_manager::Config for Runtime {
 	type SelfLocation = SelfLocation;
 	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type RelayChainAssetId = RelayChainAssetId;
-	type MinimumRemoteStashBalance = MinimumRemoteStashBalance;
+	type StakingThreshold = (MinimumRemoteReserveBalance, MinimumBondExtra);
 	type Assets = Currencies;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmAssetTransfer = XTokens;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -618,7 +618,7 @@ impl pallet_remote_asset_manager::Config for Runtime {
 	type SelfLocation = SelfLocation;
 	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type RelayChainAssetId = RelayChainAssetId;
-	type MinimumRemoteStashBalance = MinimumRemoteStashBalance;
+	type StakingThreshold = (MinimumRemoteReserveBalance, MinimumBondExtra);
 	type Assets = Currencies;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmAssetTransfer = XTokens;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -620,7 +620,7 @@ impl pallet_remote_asset_manager::Config for Runtime {
 	type SelfLocation = SelfLocation;
 	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type RelayChainAssetId = RelayChainAssetId;
-	type MinimumRemoteStashBalance = MinimumRemoteStashBalance;
+	type StakingThreshold = (MinimumRemoteReserveBalance, MinimumBondExtra);
 	type Assets = Currencies;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmAssetTransfer = XTokens;


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- This handles xcm staking related calls on a per block basis, rather than on a per deposit/withdrawal basis
- upon block initialization we check whether we need to dispatch a xcm which should succeed because we expect only valid assets to be available for staking. The fees for the weight should be paid for by the LP upon deposit/withdrawal where worst case is 1 deposit /withdrawal is 1 XCM.

This requires some additional work regarding automated rebond/withdraw and still leaves some room for simplifications with the existing xcm extrinsics, which I'll follow up on a new PR. As well as advanced testing.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #244