### PR TITLE
feat(runtime): checking and renaming origins for all pallets

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -342,7 +342,7 @@ pub mod pallet {
 		/// into the sovereign account of either:
 		/// - the given `recipient` if provided
 		/// - the caller's account if `recipient` is `None`
-		#[pallet::weight(T::WeightInfo::remove_asset())] // TODO: Set weights
+		#[pallet::weight(T::WeightInfo::remove_asset())]
 		pub fn remove_asset(
 			origin: OriginFor<T>,
 			asset_id: T::AssetId,
@@ -479,7 +479,7 @@ pub mod pallet {
 		///
 		/// The distribution of the underlying assets will be equivalent to the
 		/// ratio of the liquid assets in the index.
-		#[pallet::weight(T::WeightInfo::withdraw())] // TODO: Set weights
+		#[pallet::weight(T::WeightInfo::withdraw())]
 		#[transactional]
 		pub fn withdraw(origin: OriginFor<T>, amount: T::Balance) -> DispatchResultWithPostInfo {
 			let caller = ensure_signed(origin)?;
@@ -564,7 +564,7 @@ pub mod pallet {
 		/// as soon as the aforementioned conditions are met, regardless of
 		/// whether the other `AssetWithdrawal`s in the same `PendingWithdrawal` set
 		/// can also be closed successfully.
-		#[pallet::weight(T::WeightInfo::complete_withdraw())] // TODO: Set weights
+		#[pallet::weight(T::WeightInfo::complete_withdraw())]
 		pub fn complete_withdraw(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let caller = ensure_signed(origin)?;
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -5,4 +5,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 pub mod constants;
 pub mod traits;
+pub mod types;
 pub mod weights;

--- a/runtime/common/src/types.rs
+++ b/runtime/common/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 /// Origin that approved by committee
-pub type EnsureApprovedByCommittee<AccountId, Runtime> = frame_system::EnsureOneOf<
+pub type GovernanceOrigin<AccountId, Runtime> = frame_system::EnsureOneOf<
 	AccountId,
 	frame_system::EnsureRoot<AccountId>,
 	pallet_committee::EnsureApprovedByCommittee<Runtime>,

--- a/runtime/common/src/types.rs
+++ b/runtime/common/src/types.rs
@@ -1,0 +1,9 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/// Origin that approved by committee
+pub type EnsureApprovedByCommittee<AccountId, Runtime> = frame_system::EnsureOneOf<
+	AccountId,
+	frame_system::EnsureRoot<AccountId>,
+	pallet_committee::EnsureApprovedByCommittee<Runtime>,
+>;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
+pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -425,7 +425,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, weights};
+pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee;
+	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -416,12 +416,6 @@ impl pallet_saft_registry::Config for Runtime {
 	type WeightInfo = weights::pallet_saft_registry::WeightInfo<Runtime>;
 }
 
-type EnsureApprovedByCommittee = frame_system::EnsureOneOf<
-	AccountId,
-	frame_system::EnsureRoot<AccountId>,
-	pallet_committee::EnsureApprovedByCommittee<Runtime>,
->;
-
 impl pallet_committee::Config for Runtime {
 	type Origin = Origin;
 	type Action = Call;
@@ -431,7 +425,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee;
+	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -407,8 +407,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	// Using signed as the admin origin for now
-	type AdminOrigin = frame_system::EnsureSigned<AccountId>;
+	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
+pub use pint_runtime_common::{constants::*, types::GovernanceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type UpdateOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -407,7 +407,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type AdminOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;
@@ -424,13 +424,12 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }
 
 impl pallet_price_feed::Config for Runtime {
-	// Using root as the admin origin for now
 	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
 	type SelfAssetId = PINTAssetId;
 	type AssetId = AssetId;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, weights};
+pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -382,7 +382,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee;
+	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -414,12 +414,6 @@ impl pallet_saft_registry::Config for Runtime {
 	type WeightInfo = weights::pallet_saft_registry::WeightInfo<Runtime>;
 }
 
-type EnsureApprovedByCommittee = frame_system::EnsureOneOf<
-	AccountId,
-	frame_system::EnsureRoot<AccountId>,
-	pallet_committee::EnsureApprovedByCommittee<Runtime>,
->;
-
 impl pallet_committee::Config for Runtime {
 	type Origin = Origin;
 	type Action = Call;
@@ -429,7 +423,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee;
+	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -405,8 +405,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	// Using signed as the admin origin for now
-	type AdminOrigin = frame_system::EnsureSigned<AccountId>;
+	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
+pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -382,7 +382,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -423,7 +423,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
+pub use pint_runtime_common::{constants::*, types::GovernanceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -382,7 +382,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type UpdateOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -405,7 +405,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type AdminOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;
@@ -422,7 +422,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
+pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -425,7 +425,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }
@@ -456,7 +456,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 
 impl pallet_asset_index::Config for Runtime {
 	// Using signed as the admin origin for testing now
-	type AdminOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
+	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type IndexToken = Balances;
 	type Balance = Balance;
 	type LockupPeriod = LockupPeriod;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, types::GoveranceOrigin, weights};
+pub use pint_runtime_common::{constants::*, types::GovernanceOrigin, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type UpdateOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -407,7 +407,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type AdminOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;
@@ -424,7 +424,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }
@@ -454,7 +454,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 }
 
 impl pallet_asset_index::Config for Runtime {
-	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
+	type AdminOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type IndexToken = Balances;
 	type Balance = Balance;
 	type LockupPeriod = LockupPeriod;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -56,7 +56,7 @@ use xcm_executor::XcmExecutor;
 
 use frame_support::traits::Everything;
 use pallet_committee::EnsureMember;
-pub use pint_runtime_common::{constants::*, weights};
+pub use pint_runtime_common::{constants::*, types::EnsureApprovedByCommittee, weights};
 use primitives::traits::MultiAssetRegistry;
 pub use primitives::*;
 use xcm_calls::{
@@ -384,7 +384,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_collator_selection::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = EnsureApprovedByCommittee;
+	type UpdateOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
 	type MinCandidates = MinCandidates;
@@ -416,12 +416,6 @@ impl pallet_saft_registry::Config for Runtime {
 	type WeightInfo = weights::pallet_saft_registry::WeightInfo<Runtime>;
 }
 
-type EnsureApprovedByCommittee = frame_system::EnsureOneOf<
-	AccountId,
-	frame_system::EnsureRoot<AccountId>,
-	pallet_committee::EnsureApprovedByCommittee<Runtime>,
->;
-
 impl pallet_committee::Config for Runtime {
 	type Origin = Origin;
 	type Action = Call;
@@ -431,7 +425,7 @@ impl pallet_committee::Config for Runtime {
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee;
+	type ApprovedByCommitteeOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;
 }

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -407,8 +407,7 @@ impl pallet_local_treasury::Config for Runtime {
 }
 
 impl pallet_saft_registry::Config for Runtime {
-	// Using signed as the admin origin for now
-	type AdminOrigin = frame_system::EnsureSigned<AccountId>;
+	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type AssetRecorder = AssetIndex;
 	type Balance = Balance;
 	type AssetId = AssetId;
@@ -455,7 +454,6 @@ impl pallet_chainlink_feed::Config for Runtime {
 }
 
 impl pallet_asset_index::Config for Runtime {
-	// Using signed as the admin origin for testing now
 	type AdminOrigin = GoveranceOrigin<AccountId, Runtime>;
 	type IndexToken = Balances;
 	type Balance = Balance;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -456,7 +456,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 
 impl pallet_asset_index::Config for Runtime {
 	// Using signed as the admin origin for testing now
-	type AdminOrigin = frame_system::EnsureSigned<AccountId>;
+	type AdminOrigin = EnsureApprovedByCommittee<AccountId, Runtime>;
 	type IndexToken = Balances;
 	type Balance = Balance;
 	type LockupPeriod = LockupPeriod;


### PR DESCRIPTION
## Changes

- [x] rename `EnsureApprovedByCommittee` origin to `GoveranceOrigin`
- [x] use `GoveranceOrigin` in pallet `asset-index`
- [x] use `GoveranceOrigin` in pallet `saft-registry`

## Tests

```
CI
```

## Issues
- #301 
- Closes #268 