### PR TITLE
feat: add MaybeAssetIdConvert trait for runtime benchmarks

### DIFF
--- a/pallets/asset-index/Cargo.toml
+++ b/pallets/asset-index/Cargo.toml
@@ -67,6 +67,7 @@ runtime-benchmarks = [
     'frame-support/runtime-benchmarks',
     'pallet-price-feed/runtime-benchmarks',
 #    'pallet-chainlink-feed/runtime-benchmarks',
+    'primitives/runtime-benchmarks',
 ]
 
 [package.metadata.docs.rs]

--- a/pallets/asset-index/src/benchmarking.rs
+++ b/pallets/asset-index/src/benchmarking.rs
@@ -13,10 +13,7 @@ use frame_support::{
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use pallet_price_feed::{PriceFeed, PriceFeedBenchmarks};
-use primitives::{
-	traits::{MaybeTryFrom, NavProvider},
-	AssetAvailability,
-};
+use primitives::{traits::NavProvider, AssetAvailability};
 use xcm::v0::MultiLocation;
 
 use crate::Pallet as AssetIndex;
@@ -37,7 +34,7 @@ fn whitelist_acc<T: Config>(acc: &T::AccountId) {
 
 benchmarks! {
 	add_asset {
-		let asset_id =  T::AssetId::try_from(1u8).unwrap();
+		let asset_id :T::AssetId = T::try_convert(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let million = 1_000_000u32.into();
 		let location = MultiLocation::Null;
@@ -60,7 +57,7 @@ benchmarks! {
 	}
 
 	complete_withdraw {
-		let asset_id = T::AssetId::try_from(1u8).unwrap();
+		let asset_id : T::AssetId = T::try_convert(1u8).unwrap();
 		let units = 100_u32.into();
 		let tokens = 500_u32.into();
 		let admin = T::AdminOrigin::successful_origin();
@@ -100,7 +97,7 @@ benchmarks! {
 
 	deposit {
 		// ASSET_A_ID
-		let asset_id = T::AssetId::try_from(2u8).unwrap();
+		let asset_id : T::AssetId = T::try_convert(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let depositor = whitelisted_account::<T>("depositor", 0);
 		let admin_deposit = 5u32.into();
@@ -128,7 +125,7 @@ benchmarks! {
 	}
 
 	remove_asset {
-		let asset_id =  T::AssetId::try_from(1u8).unwrap();
+		let asset_id :T::AssetId =  T::try_convert(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let units: u32 = 100;
 		let amount = 500u32.into();
@@ -151,7 +148,7 @@ benchmarks! {
 	}
 
 	register_asset {
-		let asset_id =  T::AssetId::try_from(1u8).unwrap();
+		let asset_id :T::AssetId =  T::try_convert(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let availability = AssetAvailability::Saft;
 		let call = Call::<T>::register_asset(
@@ -166,7 +163,7 @@ benchmarks! {
 	}
 
 	set_metadata {
-		let asset_id =  T::AssetId::try_from(0u8).unwrap();
+		let asset_id :T::AssetId =  T::try_convert(0u8).unwrap();
 		let name = b"pint".to_vec();
 		let symbol = b"pint".to_vec();
 		let decimals = 8_u8;
@@ -185,7 +182,7 @@ benchmarks! {
 	}
 
 	withdraw {
-		let asset_id =  T::AssetId::try_from(1u8).unwrap();
+		let asset_id :T::AssetId =  T::try_convert(1u8).unwrap();
 		let units = 100_u32.into();
 		let tokens = 500_u32.into();
 		let admin = T::AdminOrigin::successful_origin();
@@ -219,7 +216,7 @@ benchmarks! {
 	}
 
 	unlock {
-		let asset_id =  T::AssetId::try_from(1u8).unwrap();
+		let asset_id :T::AssetId =  T::try_convert(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let depositor = whitelisted_account::<T>("depositor", 0);
 		let amount = 500u32.into();

--- a/pallets/asset-index/src/benchmarking.rs
+++ b/pallets/asset-index/src/benchmarking.rs
@@ -8,13 +8,15 @@ use frame_support::{
 	assert_ok,
 	dispatch::UnfilteredDispatchable,
 	sp_runtime::{traits::AccountIdConversion, FixedPointNumber},
-	sp_std::convert::TryFrom,
 	traits::{Currency as _, EnsureOrigin, Get},
 };
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use pallet_price_feed::{PriceFeed, PriceFeedBenchmarks};
-use primitives::{traits::NavProvider, AssetAvailability};
+use primitives::{
+	traits::{MaybeTryFrom, NavProvider},
+	AssetAvailability,
+};
 use xcm::v0::MultiLocation;
 
 use crate::Pallet as AssetIndex;
@@ -35,7 +37,7 @@ fn whitelist_acc<T: Config>(acc: &T::AccountId) {
 
 benchmarks! {
 	add_asset {
-		let asset_id =  T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let million = 1_000_000u32.into();
 		let location = MultiLocation::Null;
@@ -58,7 +60,7 @@ benchmarks! {
 	}
 
 	complete_withdraw {
-		let asset_id = T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id = T::AssetId::try_from(1u8).unwrap();
 		let units = 100_u32.into();
 		let tokens = 500_u32.into();
 		let admin = T::AdminOrigin::successful_origin();
@@ -98,7 +100,7 @@ benchmarks! {
 
 	deposit {
 		// ASSET_A_ID
-		let asset_id = T::AssetId::try_from(2u8).ok().unwrap();
+		let asset_id = T::AssetId::try_from(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let depositor = whitelisted_account::<T>("depositor", 0);
 		let admin_deposit = 5u32.into();
@@ -126,7 +128,7 @@ benchmarks! {
 	}
 
 	remove_asset {
-		let asset_id =  T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let units: u32 = 100;
 		let amount = 500u32.into();
@@ -149,7 +151,7 @@ benchmarks! {
 	}
 
 	register_asset {
-		let asset_id =  T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let availability = AssetAvailability::Saft;
 		let call = Call::<T>::register_asset(
@@ -164,7 +166,7 @@ benchmarks! {
 	}
 
 	set_metadata {
-		let asset_id =  T::AssetId::try_from(0u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(0u8).unwrap();
 		let name = b"pint".to_vec();
 		let symbol = b"pint".to_vec();
 		let decimals = 8_u8;
@@ -183,7 +185,7 @@ benchmarks! {
 	}
 
 	withdraw {
-		let asset_id =  T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(1u8).unwrap();
 		let units = 100_u32.into();
 		let tokens = 500_u32.into();
 		let admin = T::AdminOrigin::successful_origin();
@@ -217,7 +219,7 @@ benchmarks! {
 	}
 
 	unlock {
-		let asset_id =  T::AssetId::try_from(1u8).ok().unwrap();
+		let asset_id =  T::AssetId::try_from(1u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let depositor = whitelisted_account::<T>("depositor", 0);
 		let amount = 500u32.into();

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -54,12 +54,12 @@ pub mod pallet {
 	};
 
 	use crate::types::{AssetMetadata, AssetRedemption, AssetWithdrawal, IndexTokenLock, PendingRedemption};
-	use primitives::traits::MaybeTryFrom;
+	use primitives::traits::MaybeAssetIdConvert;
 
 	type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + MaybeAssetIdConvert<u8, Self::AssetId> {
 		/// Origin that is allowed to administer the index
 		type AdminOrigin: EnsureOrigin<Self::Origin>;
 		/// Currency implementation to use as the index token
@@ -96,7 +96,7 @@ pub mod pallet {
 		/// Type that handles cross chain transfers
 		type RemoteAssetManager: RemoteAssetManager<Self::AccountId, Self::AssetId, Self::Balance>;
 		/// Type used to identify assets
-		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
+		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize;
 
 		/// The native asset id
 		#[pallet::constant]

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -35,11 +35,7 @@ pub mod pallet {
 			traits::{AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedDiv, CheckedSub, Saturating, Zero},
 			ArithmeticError, FixedPointNumber,
 		},
-		sp_std::{
-			convert::{TryFrom, TryInto},
-			prelude::*,
-			result::Result,
-		},
+		sp_std::{convert::TryInto, prelude::*, result::Result},
 		traits::{Currency, ExistenceRequirement, Get, LockIdentifier, LockableCurrency, WithdrawReasons},
 		transactional, PalletId,
 	};
@@ -58,6 +54,7 @@ pub mod pallet {
 	};
 
 	use crate::types::{AssetMetadata, AssetRedemption, AssetWithdrawal, IndexTokenLock, PendingRedemption};
+	use primitives::traits::MaybeTryFrom;
 
 	type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 
@@ -99,7 +96,7 @@ pub mod pallet {
 		/// Type that handles cross chain transfers
 		type RemoteAssetManager: RemoteAssetManager<Self::AccountId, Self::AssetId, Self::Balance>;
 		/// Type used to identify assets
-		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + TryFrom<u8>;
+		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
 
 		/// The native asset id
 		#[pallet::constant]

--- a/pallets/price-feed/Cargo.toml
+++ b/pallets/price-feed/Cargo.toml
@@ -44,6 +44,7 @@ runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'pallet-chainlink-feed/runtime-benchmarks',
+    'primitives/runtime-benchmarks',
 ]
 
 [package.metadata.docs.rs]

--- a/pallets/price-feed/src/benchmarking.rs
+++ b/pallets/price-feed/src/benchmarking.rs
@@ -6,13 +6,12 @@
 use super::*;
 use frame_benchmarking::benchmarks;
 use frame_support::{assert_ok, dispatch::UnfilteredDispatchable, sp_std::convert::TryInto, traits::EnsureOrigin};
-use primitives::traits::MaybeTryFrom;
 
 use crate::Pallet as PriceFeed;
 
 benchmarks! {
 	map_asset_price_feed {
-		let asset_id = T::AssetId::try_from(2u8).unwrap();
+		let asset_id :T::AssetId = T::try_convert(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let feed_id = 0u32.try_into().ok().unwrap();
 		let call = Call::<T>::map_asset_price_feed(
@@ -27,7 +26,7 @@ benchmarks! {
 	}
 
 	unmap_asset_price_feed {
-		let asset_id = T::AssetId::try_from(2u8).unwrap();
+		let asset_id :T::AssetId = T::try_convert(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let feed_id = 0u32.try_into().ok().unwrap();
 		assert_ok!(PriceFeed::<T>::map_asset_price_feed(origin.clone(), asset_id.clone(), feed_id));

--- a/pallets/price-feed/src/benchmarking.rs
+++ b/pallets/price-feed/src/benchmarking.rs
@@ -5,18 +5,14 @@
 
 use super::*;
 use frame_benchmarking::benchmarks;
-use frame_support::{
-	assert_ok,
-	dispatch::UnfilteredDispatchable,
-	sp_std::convert::{TryFrom, TryInto},
-	traits::EnsureOrigin,
-};
+use frame_support::{assert_ok, dispatch::UnfilteredDispatchable, sp_std::convert::TryInto, traits::EnsureOrigin};
+use primitives::traits::MaybeTryFrom;
 
 use crate::Pallet as PriceFeed;
 
 benchmarks! {
 	map_asset_price_feed {
-		let asset_id = T::AssetId::try_from(2u8).ok().unwrap();
+		let asset_id = T::AssetId::try_from(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let feed_id = 0u32.try_into().ok().unwrap();
 		let call = Call::<T>::map_asset_price_feed(
@@ -31,7 +27,7 @@ benchmarks! {
 	}
 
 	unmap_asset_price_feed {
-		let asset_id = T::AssetId::try_from(2u8).ok().unwrap();
+		let asset_id = T::AssetId::try_from(2u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let feed_id = 0u32.try_into().ok().unwrap();
 		assert_ok!(PriceFeed::<T>::map_asset_price_feed(origin.clone(), asset_id.clone(), feed_id));

--- a/pallets/price-feed/src/lib.rs
+++ b/pallets/price-feed/src/lib.rs
@@ -50,11 +50,11 @@ pub mod pallet {
 	use frame_support::{
 		pallet_prelude::*,
 		sp_runtime::{traits::CheckedDiv, FixedPointNumber, FixedPointOperand},
-		sp_std::convert::TryFrom,
 		traits::{Get, Time},
 	};
 	use frame_system::pallet_prelude::*;
 	use pallet_chainlink_feed::{FeedInterface, FeedOracle, RoundData};
+	use primitives::traits::MaybeTryFrom;
 	pub use primitives::{AssetPricePair, Price};
 
 	pub type FeedIdFor<T> = <T as pallet_chainlink_feed::Config>::FeedId;
@@ -82,7 +82,7 @@ pub mod pallet {
 		type SelfAssetId: Get<Self::AssetId>;
 
 		/// Type used to identify the assets.
-		type AssetId: Parameter + Member + MaybeSerializeDeserialize + TryFrom<u8>;
+		type AssetId: Parameter + Member + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
 
 		/// Type to keep track of timestamped values
 		type Time: Time;

--- a/pallets/price-feed/src/lib.rs
+++ b/pallets/price-feed/src/lib.rs
@@ -54,7 +54,7 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use pallet_chainlink_feed::{FeedInterface, FeedOracle, RoundData};
-	use primitives::traits::MaybeTryFrom;
+	use primitives::traits::MaybeAssetIdConvert;
 	pub use primitives::{AssetPricePair, Price};
 
 	pub type FeedIdFor<T> = <T as pallet_chainlink_feed::Config>::FeedId;
@@ -73,7 +73,9 @@ pub mod pallet {
 	/// (`quote`/`asset`) from the oracle, its price is given by
 	/// means of the asset pair `(base / quote)`. (e.g. DOT/PINT)
 	#[pallet::config]
-	pub trait Config: frame_system::Config + pallet_chainlink_feed::Config {
+	pub trait Config:
+		frame_system::Config + pallet_chainlink_feed::Config + MaybeAssetIdConvert<u8, Self::AssetId>
+	{
 		/// The origin that is allowed to insert asset -> feed mappings
 		type AdminOrigin: EnsureOrigin<Self::Origin>;
 
@@ -82,7 +84,7 @@ pub mod pallet {
 		type SelfAssetId: Get<Self::AssetId>;
 
 		/// Type used to identify the assets.
-		type AssetId: Parameter + Member + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
+		type AssetId: Parameter + Member + MaybeSerializeDeserialize;
 
 		/// Type to keep track of timestamped values
 		type Time: Time;

--- a/pallets/price-feed/src/mock.rs
+++ b/pallets/price-feed/src/mock.rs
@@ -123,11 +123,11 @@ impl pallet_chainlink_feed::Config for Test {
 	type WeightInfo = ();
 }
 
-pub(crate) type AssetId = u64;
+pub(crate) type AssetId = u32;
 pub(crate) const ADMIN_ACCOUNT_ID: AccountId = 88;
 
 parameter_types! {
-	pub const PINTAssetId: AssetId = 1u64;
+	pub const PINTAssetId: AssetId = 1u32;
 }
 
 ord_parameter_types! {

--- a/pallets/remote-asset-manager/Cargo.toml
+++ b/pallets/remote-asset-manager/Cargo.toml
@@ -110,6 +110,7 @@ runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'frame-system/runtime-benchmarks',
+    'primitives/runtime-benchmarks',
 ]
 
 [package.metadata.docs.rs]

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -36,7 +36,7 @@ pub mod pallet {
 	use orml_traits::{location::Parse, MultiCurrency, XcmTransfer};
 	use xcm::v0::{Error as XcmError, ExecuteXcm, MultiLocation, OriginKind, Result as XcmResult, SendXcm, Xcm};
 
-	use primitives::traits::{MaybeTryFrom, MultiAssetRegistry, RemoteAssetManager};
+	use primitives::traits::{MaybeAssetIdConvert, MultiAssetRegistry, RemoteAssetManager};
 	use xcm_calls::{
 		proxy::{ProxyCall, ProxyCallEncoder, ProxyConfig, ProxyParams, ProxyState, ProxyType, ProxyWeights},
 		staking::{
@@ -69,7 +69,7 @@ pub mod pallet {
 	type PalletProxyCall<T> = ProxyCall<AccountIdFor<T>, ProxyType, <T as frame_system::Config>::BlockNumber>;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + MaybeAssetIdConvert<u8, Self::AssetId> {
 		/// The balance type for cross chain transfers
 		type Balance: Parameter
 			+ Member
@@ -80,7 +80,7 @@ pub mod pallet {
 			+ Into<u128>;
 
 		/// Asset Id that is used to identify different kinds of assets.
-		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
+		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize;
 
 		/// Convert a `T::AssetId` to its relative `MultiLocation` identifier.
 		type AssetIdConvert: Convert<Self::AssetId, Option<MultiLocation>>;

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -28,7 +28,7 @@ pub mod pallet {
 		dispatch::DispatchResultWithPostInfo,
 		pallet_prelude::*,
 		sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned, Convert, Saturating, StaticLookup, Zero},
-		sp_std::{self, convert::TryFrom, mem, prelude::*},
+		sp_std::{self, mem, prelude::*},
 		traits::Get,
 		transactional,
 	};
@@ -36,7 +36,7 @@ pub mod pallet {
 	use orml_traits::{location::Parse, MultiCurrency, XcmTransfer};
 	use xcm::v0::{Error as XcmError, ExecuteXcm, MultiLocation, OriginKind, Result as XcmResult, SendXcm, Xcm};
 
-	use primitives::traits::{MultiAssetRegistry, RemoteAssetManager};
+	use primitives::traits::{MaybeTryFrom, MultiAssetRegistry, RemoteAssetManager};
 	use xcm_calls::{
 		proxy::{ProxyCall, ProxyCallEncoder, ProxyConfig, ProxyParams, ProxyState, ProxyType, ProxyWeights},
 		staking::{
@@ -80,7 +80,7 @@ pub mod pallet {
 			+ Into<u128>;
 
 		/// Asset Id that is used to identify different kinds of assets.
-		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + TryFrom<u8>;
+		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaybeTryFrom<u8>;
 
 		/// Convert a `T::AssetId` to its relative `MultiLocation` identifier.
 		type AssetIdConvert: Convert<Self::AssetId, Option<MultiLocation>>;

--- a/pallets/saft-registry/Cargo.toml
+++ b/pallets/saft-registry/Cargo.toml
@@ -59,4 +59,5 @@ runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'pallet-asset-index/runtime-benchmarks',
+    'primitives/runtime-benchmarks',
 ]

--- a/pallets/saft-registry/src/benchmarking.rs
+++ b/pallets/saft-registry/src/benchmarking.rs
@@ -5,7 +5,6 @@
 
 use frame_benchmarking::benchmarks;
 use frame_support::{assert_ok, dispatch::UnfilteredDispatchable, sp_runtime::traits::Zero, traits::EnsureOrigin};
-use primitives::traits::MaybeTryFrom;
 use xcm::v0::Junction;
 
 use crate::Pallet as SaftRegistry;
@@ -16,7 +15,7 @@ const MAX_SAFT_RECORDS: u32 = 100;
 
 benchmarks! {
 	add_saft {
-		let asset= T::AssetId::try_from(0u8).unwrap();
+		let asset: T::AssetId = T::try_convert(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let call = Call::<T>::add_saft(
 				asset,
@@ -33,7 +32,7 @@ benchmarks! {
 	}
 
 	remove_saft {
-		let asset= T::AssetId::try_from(0u8).unwrap();
+		let asset: T::AssetId = T::try_convert(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		assert_ok!(SaftRegistry::<T>::add_saft(origin.clone(), asset, 100u32.into(), 20u32.into()));
 		let call = Call::<T>::remove_saft(
@@ -48,7 +47,7 @@ benchmarks! {
 	}
 
 	report_nav {
-		let asset= T::AssetId::try_from(0u8).unwrap();
+		let asset: T::AssetId = T::try_convert(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		assert_ok!(SaftRegistry::<T>::add_saft(
 			origin.clone(),
@@ -72,7 +71,7 @@ benchmarks! {
 	convert_to_liquid {
 		let nav = 1337u32;
 		let units = 1234u32;
-		let asset= T::AssetId::try_from(0u8).unwrap();
+		let asset:T::AssetId = T::try_convert(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		// Create saft records
 		for i in 0 .. MAX_SAFT_RECORDS {

--- a/pallets/saft-registry/src/benchmarking.rs
+++ b/pallets/saft-registry/src/benchmarking.rs
@@ -4,10 +4,8 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use frame_benchmarking::benchmarks;
-use frame_support::{
-	assert_ok, dispatch::UnfilteredDispatchable, sp_runtime::traits::Zero, sp_std::convert::TryFrom,
-	traits::EnsureOrigin,
-};
+use frame_support::{assert_ok, dispatch::UnfilteredDispatchable, sp_runtime::traits::Zero, traits::EnsureOrigin};
+use primitives::traits::MaybeTryFrom;
 use xcm::v0::Junction;
 
 use crate::Pallet as SaftRegistry;
@@ -18,7 +16,7 @@ const MAX_SAFT_RECORDS: u32 = 100;
 
 benchmarks! {
 	add_saft {
-		let asset= T::AssetId::try_from(0u8).ok().unwrap();
+		let asset= T::AssetId::try_from(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		let call = Call::<T>::add_saft(
 				asset,
@@ -35,7 +33,7 @@ benchmarks! {
 	}
 
 	remove_saft {
-		let asset= T::AssetId::try_from(0u8).ok().unwrap();
+		let asset= T::AssetId::try_from(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		assert_ok!(SaftRegistry::<T>::add_saft(origin.clone(), asset, 100u32.into(), 20u32.into()));
 		let call = Call::<T>::remove_saft(
@@ -50,7 +48,7 @@ benchmarks! {
 	}
 
 	report_nav {
-		let asset= T::AssetId::try_from(0u8).ok().unwrap();
+		let asset= T::AssetId::try_from(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		assert_ok!(SaftRegistry::<T>::add_saft(
 			origin.clone(),
@@ -74,7 +72,7 @@ benchmarks! {
 	convert_to_liquid {
 		let nav = 1337u32;
 		let units = 1234u32;
-		let asset= T::AssetId::try_from(0u8).ok().unwrap();
+		let asset= T::AssetId::try_from(0u8).unwrap();
 		let origin = T::AdminOrigin::successful_origin();
 		// Create saft records
 		for i in 0 .. MAX_SAFT_RECORDS {

--- a/pallets/saft-registry/src/lib.rs
+++ b/pallets/saft-registry/src/lib.rs
@@ -24,12 +24,12 @@ pub mod pallet {
 			traits::{AtLeast32BitUnsigned, CheckedAdd, One, Saturating, Zero},
 			ArithmeticError,
 		},
-		sp_std::{self, convert::TryFrom, prelude::*, result::Result},
+		sp_std::{self, prelude::*, result::Result},
 		transactional,
 	};
 	use frame_system::pallet_prelude::*;
 	use primitives::{
-		traits::{AssetRecorder, SaftRegistry},
+		traits::{AssetRecorder, MaybeTryFrom, SaftRegistry},
 		types::AssetAvailability,
 		SAFTId,
 	};
@@ -41,7 +41,7 @@ pub mod pallet {
 		type AdminOrigin: EnsureOrigin<Self::Origin>;
 		type AssetRecorder: AssetRecorder<Self::AccountId, Self::AssetId, Self::Balance>;
 		type Balance: Parameter + Member + AtLeast32BitUnsigned + Default + Copy;
-		type AssetId: Parameter + Member + Copy + TryFrom<u8>;
+		type AssetId: Parameter + Member + Copy + MaybeTryFrom<u8>;
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The weight for this pallet's extrinsics.
 		type WeightInfo: WeightInfo;

--- a/pallets/saft-registry/src/lib.rs
+++ b/pallets/saft-registry/src/lib.rs
@@ -29,19 +29,19 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use primitives::{
-		traits::{AssetRecorder, MaybeTryFrom, SaftRegistry},
+		traits::{AssetRecorder, MaybeAssetIdConvert, SaftRegistry},
 		types::AssetAvailability,
 		SAFTId,
 	};
 	use xcm::v0::MultiLocation;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + MaybeAssetIdConvert<u8, Self::AssetId> {
 		// Origin that is allowed to manage the SAFTs
 		type AdminOrigin: EnsureOrigin<Self::Origin>;
 		type AssetRecorder: AssetRecorder<Self::AccountId, Self::AssetId, Self::Balance>;
 		type Balance: Parameter + Member + AtLeast32BitUnsigned + Default + Copy;
-		type AssetId: Parameter + Member + Copy + MaybeTryFrom<u8>;
+		type AssetId: Parameter + Member + Copy;
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The weight for this pallet's extrinsics.
 		type WeightInfo: WeightInfo;

--- a/primitives/primitives/Cargo.toml
+++ b/primitives/primitives/Cargo.toml
@@ -26,7 +26,6 @@ std = [
     'frame-system/std',
     'xcm/std',
 ]
-# this feature is only for compilation now
 runtime-benchmarks = []
 
 [package.metadata.docs.rs]

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -257,35 +257,31 @@ pub trait AssetRecorder<AccountId, AssetId, Balance> {
 	/// the nav from the caller's account
 	fn remove_saft(who: AccountId, id: AssetId, units: Balance, nav: Balance) -> DispatchResult;
 }
-
-/// This is a helper trait used for constructing types in Runtime Benchmarks
-pub trait MaybeTryFrom<T>: Sized {
+/// This is a helper trait only used for constructing `AssetId` types in Runtime Benchmarks
+pub trait MaybeAssetIdConvert<A, B>: Sized {
 	#[cfg(feature = "runtime-benchmarks")]
-	fn try_from(value: T) -> Option<Self>;
+	fn try_convert(value: A) -> Option<B>;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-impl MaybeTryFrom<u8> for crate::types::AssetId {
-	fn try_from(value: u8) -> Option<Self> {
+impl<T> MaybeAssetIdConvert<u8, crate::types::AssetId> for T {
+	fn try_convert(value: u8) -> Option<crate::types::AssetId> {
 		frame_support::sp_std::convert::TryFrom::try_from(value).ok()
 	}
 }
 
 #[cfg(not(feature = "runtime-benchmarks"))]
-impl<T, S> MaybeTryFrom<S> for T {}
+impl<T, A, B> MaybeAssetIdConvert<A, B> for T {}
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::AssetId;
 
-	fn assert_maybe_from<T: MaybeTryFrom<u8>>() {}
+	fn assert_maybe_from<T: MaybeAssetIdConvert<u8, AssetId>>() {}
 
 	#[test]
 	fn maybe_from_works() {
-		assert_maybe_from::<AssetId>();
-
-		#[cfg(feature = "runtime-benchmarks")]
-		assert_eq!(Some(10 as AssetId), MaybeTryFrom::try_from(10u8));
+		assert_maybe_from::<()>();
 	}
 }

--- a/primitives/primitives/src/traits.rs
+++ b/primitives/primitives/src/traits.rs
@@ -257,3 +257,35 @@ pub trait AssetRecorder<AccountId, AssetId, Balance> {
 	/// the nav from the caller's account
 	fn remove_saft(who: AccountId, id: AssetId, units: Balance, nav: Balance) -> DispatchResult;
 }
+
+/// This is a helper trait used for constructing types in Runtime Benchmarks
+pub trait MaybeTryFrom<T>: Sized {
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_from(value: T) -> Option<Self>;
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl MaybeTryFrom<u8> for crate::types::AssetId {
+	fn try_from(value: u8) -> Option<Self> {
+		frame_support::sp_std::convert::TryFrom::try_from(value).ok()
+	}
+}
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+impl<T, S> MaybeTryFrom<S> for T {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::AssetId;
+
+	fn assert_maybe_from<T: MaybeTryFrom<u8>>() {}
+
+	#[test]
+	fn maybe_from_works() {
+		assert_maybe_from::<AssetId>();
+
+		#[cfg(feature = "runtime-benchmarks")]
+		assert_eq!(Some(10 as AssetId), MaybeTryFrom::try_from(10u8));
+	}
+}

--- a/primitives/primitives/src/types.rs
+++ b/primitives/primitives/src/types.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 ChainSafe Systems
 // SPDX-License-Identifier: LGPL-3.0-only
 
+//! Shareable PINT types
+
 use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::{

--- a/runtime/dev/Cargo.toml
+++ b/runtime/dev/Cargo.toml
@@ -118,12 +118,12 @@ runtime-benchmarks = [
     'pallet-price-feed/runtime-benchmarks',
     'pallet-local-treasury/runtime-benchmarks',
 	'pallet-balances/runtime-benchmarks',
-	'pallet-timestamp/runtime-benchmarks',
     'pallet-committee/runtime-benchmarks',
     'pallet-xcm/runtime-benchmarks',
     'pallet-saft-registry/runtime-benchmarks',
     'pallet-remote-asset-manager/runtime-benchmarks',
     'pallet-collective/runtime-benchmarks',
+	'primitives/runtime-benchmarks',
 
 	'orml-tokens/runtime-benchmarks',
 ]

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -118,12 +118,12 @@ runtime-benchmarks = [
     'pallet-price-feed/runtime-benchmarks',
     'pallet-local-treasury/runtime-benchmarks',
 	'pallet-balances/runtime-benchmarks',
-	'pallet-timestamp/runtime-benchmarks',
     'pallet-committee/runtime-benchmarks',
     'pallet-xcm/runtime-benchmarks',
     'pallet-saft-registry/runtime-benchmarks',
     'pallet-remote-asset-manager/runtime-benchmarks',
     'pallet-collective/runtime-benchmarks',
+	'primitives/runtime-benchmarks',
 
 	'orml-tokens/runtime-benchmarks'
 ]

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -118,12 +118,12 @@ runtime-benchmarks = [
     'pallet-price-feed/runtime-benchmarks',
     'pallet-local-treasury/runtime-benchmarks',
 	'pallet-balances/runtime-benchmarks',
-	'pallet-timestamp/runtime-benchmarks',
     'pallet-committee/runtime-benchmarks',
     'pallet-xcm/runtime-benchmarks',
     'pallet-saft-registry/runtime-benchmarks',
     'pallet-remote-asset-manager/runtime-benchmarks',
     'pallet-collective/runtime-benchmarks',
+	'primitives/runtime-benchmarks',
 
 	'orml-tokens/runtime-benchmarks'
 ]


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Use a feature gated trait to create AssetIds in runtime benchmarks

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo t --all-features
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #310 