### PR TITLE
feat(committee): only members can submit proposals

### DIFF
--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -20,7 +20,6 @@ pub use frame_support::{
 	},
 	PalletId, StorageValue,
 };
-use frame_system::EnsureSigned;
 
 // orml imports
 use orml_currencies::BasicCurrencyAdapter;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -446,7 +446,7 @@ impl pallet_committee::Config for Runtime {
 	type ProposalSubmissionPeriod = ProposalSubmissionPeriod;
 	type VotingPeriod = VotingPeriod;
 	type MinCouncilVotes = MinCouncilVotes;
-	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
+	type ProposalSubmissionOrigin = EnsureMember<Self>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
 	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -440,7 +440,7 @@ impl pallet_committee::Config for Runtime {
 	type VotingPeriod = VotingPeriod;
 	type MinCouncilVotes = MinCouncilVotes;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
-	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
+	type ProposalSubmissionOrigin = EnsureMember<Self>;
 	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;
 	type WeightInfo = weights::pallet_committee::WeightInfo<Runtime>;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -20,7 +20,6 @@ pub use frame_support::{
 	},
 	PalletId, StorageValue,
 };
-use frame_system::EnsureSigned;
 
 // orml imports
 use orml_currencies::BasicCurrencyAdapter;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -20,7 +20,6 @@ pub use frame_support::{
 	},
 	PalletId, StorageValue,
 };
-use frame_system::EnsureSigned;
 
 // orml imports
 use orml_currencies::BasicCurrencyAdapter;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -442,7 +442,7 @@ impl pallet_committee::Config for Runtime {
 	type ProposalSubmissionPeriod = ProposalSubmissionPeriod;
 	type VotingPeriod = VotingPeriod;
 	type MinCouncilVotes = MinCouncilVotes;
-	type ProposalSubmissionOrigin = EnsureSigned<AccountId>;
+	type ProposalSubmissionOrigin = EnsureMember<Self>;
 	type ProposalExecutionOrigin = EnsureMember<Self>;
 	type ApprovedByCommitteeOrigin = GovernanceOrigin<AccountId, Runtime>;
 	type Event = Event;


### PR DESCRIPTION
## Changes

Use `EnsureMember` for submission origin

---

Confusing about replacing signed origin: most of the calls of PINT requires `GovernanceOrigin` or `Member`, so what exactly people which are not of a member of the committee can do in PINT?

## Tests

```

```

## Issues

- Closes #367