### PR TITLE
review & cleanup

### DIFF
--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -1047,7 +1047,7 @@ pub mod pallet {
 			// native asset can't be added
 			Self::ensure_not_native_asset(&asset_id)?;
 			// mint asset into the treasury account
-			T::Currency::deposit(asset_id, &Self::treasury_account(), units)?; // ??? Bryan - where is this token coming from?
+			T::Currency::deposit(asset_id, &Self::treasury_account(), units)?;
 			// mint PINT into caller's balance increasing the total issuance
 			T::IndexToken::deposit_creating(caller, nav);
 			Ok(())
@@ -1077,7 +1077,7 @@ pub mod pallet {
 			let index_token = Self::saft_equivalent(saft_nav)?;
 
 			// mint the given units of the SAFT asset into the treasury's account
-			T::Currency::deposit(asset_id, &Self::treasury_account(), units)?; // ??? Bryan - what prevents this from minting other assets? e.g. DOT
+			T::Currency::deposit(asset_id, &Self::treasury_account(), units)?;
 
 			// mint PINT into caller's balance increasing the total issuance
 			T::IndexToken::deposit_creating(caller, index_token);

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -757,7 +757,7 @@ pub mod pallet {
 			units: T::Balance,
 			amount: T::Balance,
 		) -> DispatchResult {
-			Assets::<T>::get(&asset_id).ok_or(Error::<T>::AssetNotExists)?;
+			ensure!(Assets::<T>::contains_key(&asset_id), Error::<T>::AssetNotExists);
 
 			if units.is_zero() {
 				return Ok(());

--- a/pallets/asset-index/src/lib.rs
+++ b/pallets/asset-index/src/lib.rs
@@ -1138,7 +1138,7 @@ pub mod pallet {
 			units: T::Balance,
 			location: MultiLocation,
 			amount: T::Balance,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let origin = T::AdminOrigin::successful_origin();
 			let origin_account_id = T::AdminOrigin::ensure_origin(origin.clone()).unwrap();
 

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -110,7 +110,7 @@ pub mod pallet {
 
 	/// Store a mapping (hash) -> Proposal for all existing proposals.
 	#[pallet::storage]
-	pub type Proposals<T: Config> = StorageMap<_, Blake2_128Concat, HashFor<T>, Proposal<T>, OptionQuery>;
+	pub type Proposals<T: Config> = StorageMap<_, Identity, HashFor<T>, Proposal<T>, OptionQuery>;
 
 	/// Store a mapping (hash) -> () for all proposals that have been executed
 	#[pallet::storage]
@@ -247,14 +247,11 @@ pub mod pallet {
 		/// store Returns an error if the data type used for the nonce
 		/// exceeds is maximum value
 		fn take_and_increment_nonce() -> Result<T::ProposalNonce, Error<T>> {
-			let nonce = ProposalCount::<T>::get();
-			match nonce.checked_add(&T::ProposalNonce::one()) {
-				Some(next) => {
-					ProposalCount::<T>::set(next);
-					Ok(nonce)
-				}
-				None => Err(Error::ProposalNonceExhausted),
-			}
+			ProposalCount::<T>::try_mutate(|nonce| -> Result<T::ProposalNonce, Error<T>> {
+				let current = nonce.clone();
+				*nonce = current.checked_add(&One::one()).ok_or(Error::ProposalNonceExhausted)?;
+				Ok(current)
+			})
 		}
 
 		pub fn active_proposals() -> Vec<HashFor<T>> {
@@ -294,25 +291,26 @@ pub mod pallet {
 		/// `Storage: ActiveProposals (r:1 w:1) + Votes (r1) * len(proposals)`
 		fn upkeep(n: BlockNumberFor<T>) -> Weight {
 			// ActiveProposals.retain (r:1 w:1)
-			let mut consumed = T::DbWeight::get().reads_writes(1, 1);
+			let mut reads: Weight = 1;
+			let writes: Weight = 1;
 
 			// clear out proposals that are no longer active
 			ActiveProposals::<T>::mutate(|proposals| {
 				// consumed weight for all `Storage: Votes (r1)` lookups
-				let read_vote = T::DbWeight::get().reads(1);
-				consumed = consumed.saturating_add(read_vote.saturating_mul(proposals.len() as Weight));
+				reads = reads.saturating_add(proposals.len() as Weight);
 
 				proposals.retain(|hash| if let Some(votes) = Self::get_votes_for(hash) { votes.end > n } else { false })
 			});
 
-			consumed
+			T::DbWeight::get().reads_writes(reads, writes)
 		}
 
 		/// Used to check if an origin is signed and the signer is a member of
 		/// the committee
 		pub fn ensure_member(origin: OriginFor<T>) -> Result<CommitteeMember<AccountIdFor<T>>, DispatchError> {
 			let who = ensure_signed(origin)?;
-			Ok(CommitteeMember::new(who.clone(), Members::<T>::get(who).ok_or(Error::<T>::NotMember)?))
+			let members = Members::<T>::get(&who).ok_or(Error::<T>::NotMember)?;
+			Ok(CommitteeMember::new(who, members))
 		}
 	}
 

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -474,7 +474,7 @@ pub mod pallet {
 			value: T::Balance,
 			payee: RewardDestination<AccountIdFor<T>>,
 		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin.clone())?;
+			let _ = ensure_signed(origin.clone())?; // ??? Bryan - why ensure signed & ensure admin?
 			T::AdminOrigin::ensure_origin(origin)?;
 			if value.is_zero() {
 				return Ok(().into());
@@ -496,6 +496,8 @@ pub mod pallet {
 
 			let call = PalletStakingCall::<T>::Bond(Bond { controller: controller.clone(), value, payee });
 			let encoder = call.encoder::<T::PalletStakingCallEncoder>(&asset);
+
+			// ??? Bryan - who is paying for the XCM execution fee on dest chain?
 
 			let xcm = Xcm::Transact {
 				origin_type: OriginKind::SovereignAccount,
@@ -549,6 +551,8 @@ pub mod pallet {
 				delay: T::BlockNumber::zero(),
 			});
 			let encoder = call.encoder::<T::PalletProxyCallEncoder>(&asset);
+
+			// ??? Bryan - who is paying for the XCM execution fee on dest chain? also the proxy deposit
 
 			let xcm = Xcm::Transact {
 				origin_type: OriginKind::SovereignAccount,

--- a/pallets/remote-asset-manager/src/lib.rs
+++ b/pallets/remote-asset-manager/src/lib.rs
@@ -474,7 +474,6 @@ pub mod pallet {
 			value: T::Balance,
 			payee: RewardDestination<AccountIdFor<T>>,
 		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin.clone())?; // ??? Bryan - why ensure signed & ensure admin?
 			T::AdminOrigin::ensure_origin(origin)?;
 			if value.is_zero() {
 				return Ok(().into());
@@ -496,8 +495,6 @@ pub mod pallet {
 
 			let call = PalletStakingCall::<T>::Bond(Bond { controller: controller.clone(), value, payee });
 			let encoder = call.encoder::<T::PalletStakingCallEncoder>(&asset);
-
-			// ??? Bryan - who is paying for the XCM execution fee on dest chain?
 
 			let xcm = Xcm::Transact {
 				origin_type: OriginKind::SovereignAccount,
@@ -551,8 +548,6 @@ pub mod pallet {
 				delay: T::BlockNumber::zero(),
 			});
 			let encoder = call.encoder::<T::PalletProxyCallEncoder>(&asset);
-
-			// ??? Bryan - who is paying for the XCM execution fee on dest chain? also the proxy deposit
 
 			let xcm = Xcm::Transact {
 				origin_type: OriginKind::SovereignAccount,


### PR DESCRIPTION
Some minor cleanup & fixes.
Add some inline comment for questions.

Some more clone can be removed by having help method taking `&T::AccountId` instead of `T::AccountId`.
I don't see any mechanism to prevent admin from minting of other non-related assets. Some refactor is likely required to prevent it by leveraging some type system.
XCM related fee handling also needs more consideration. The fee will be paid by parachain account so the pallets needs to charge someone for the fee.. Also with new introduction of BuyWeights, the current code needs update.