### PR TITLE
chore(docker): use staging images

### DIFF
--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 #
 # Building layer
-FROM paritytech/ci-linux:production as builder
+FROM paritytech/ci-linux:staging-1.55.0-stable as builder
 COPY . .
 ENV CARGO_TERM_COLOR=always
 RUN --mount=type=cache,target=/usr/local/cargo/git \

--- a/docker/rococo.Dockerfile
+++ b/docker/rococo.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 #
 # rococo-v1
-FROM paritytech/ci-linux:production as builder
+FROM paritytech/ci-linux:staging-1.55.0-stable as builder
 COPY . .
 ENV CARGO_TERM_COLOR=always
 RUN --mount=type=cache,target=/usr/local/cargo/git \

--- a/docker/statemint.Dockerfile
+++ b/docker/statemint.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 #
 # statemint
-FROM paritytech/ci-linux:production as builder
+FROM paritytech/ci-linux:staging-1.55.0-stable as builder
 COPY . .
 ENV CARGO_TERM_COLOR=always
 RUN --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
## Changes

The latest `paritytech/ci-linux:production` could not build PINT, roll back to staging image

## Tests


```
CI
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-